### PR TITLE
Improve regex and fix doc paths to be OS agnostic.

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { Fragment } from 'react'
 
 type NavRoute = {
   url: string
@@ -35,15 +36,17 @@ function NavItem({ route }) {
 function Nav({ nav }: NavProps) {
   return (
     <ul>
-      {Object.entries(nav).map(([key, children]) => (
-        <>
+      {Object.entries(nav).map(([key, children], index) => (
+        <Fragment key={`${key}-${index}`}>
           <h3 className="px-6 mt-8 mb-2 text-lg text-gray-900 capitalize">
             {key.split('-').join(' ')}
           </h3>
-          {Object.entries(children).map(([, route]) => (
-            <NavItem route={route} />
+          {Object.entries(children).map(([key, route], index) => (
+            <Fragment key={`${key}-${index}`}>
+              <NavItem route={route} />
+            </Fragment>
           ))}
-        </>
+        </Fragment>
       ))}
     </ul>
   )

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -18,7 +18,7 @@ function NavItem({ route }) {
 
   return (
     <li>
-      <Link href={`/${route.url.replace('index', '')}`}>
+      <Link href={route.url.replace('index', '')}>
         <a
           className={clsx(
             'block px-6 py-3 text-gray-800 capitalize font-normal hover:bg-gray-100 cursor-pointer',
@@ -40,7 +40,7 @@ function Nav({ nav }: NavProps) {
           <h3 className="px-6 mt-8 mb-2 text-lg text-gray-900 capitalize">
             {key.split('-').join(' ')}
           </h3>
-          {Object.entries(children).map(([key, route]) => (
+          {Object.entries(children).map(([, route]) => (
             <NavItem route={route} />
           ))}
         </>

--- a/components/Toc.tsx
+++ b/components/Toc.tsx
@@ -17,7 +17,7 @@ function Toc({ toc }: TocProps) {
       <h3 className="mt-8 mb-2 text-lg font-medium text-gray-900 capitalize">On This Page</h3>
 
       {toc.map((item) => (
-        <h3 className={clsx(item.depth === 3 && 'ml-4')}>
+        <h3 key={item.slug} className={clsx(item.depth === 3 && 'ml-4')}>
           <a
             className="block py-2 text-base font-normal leading-6 text-gray-500 hover:underline"
             href={`#${item.slug}`}

--- a/docs/react-three-fiber/advanced/instancing.mdx
+++ b/docs/react-three-fiber/advanced/instancing.mdx
@@ -1,3 +1,3 @@
 ---
-title: [wip] Instancing
+title: '[WIP] Instancing'
 ---

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -76,10 +76,7 @@ export const getStaticProps = async ({ params }) => {
   const allDocs = await getAllDocs()
 
   const nav = allDocs.reduce((nav, file) => {
-    const [lib, ...rest] = file.url
-      .replace(/[/\\]?docs/i, '')
-      .split(path.sep)
-      .filter(Boolean)
+    const [lib, ...rest] = file.url.split('/').filter(Boolean)
     const _path = `${lib}${rest.length === 1 ? '..' : '.'}${rest.join('.')}`
 
     setValue(nav, _path, file)

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -3,26 +3,40 @@ import fs from 'fs'
 import matter from 'gray-matter'
 import recursiveReaddir from 'recursive-readdir'
 
-// DOCS_PATH is useful when you want to get the path to a specific file
+/**
+ * Useful when you want to get the path to a specific file
+ */
 export const DOCS_PATH = path.join(process.cwd(), 'docs')
 
-// postFilePaths is the list of all mdx files inside the DOCS_PATH directory
+/**
+ * Gets a list of all mdx files inside the `DOCS_PATH` directory
+ */
 export const getDocsPaths = async () =>
-  (await recursiveReaddir(DOCS_PATH))
+  ((await recursiveReaddir(DOCS_PATH)) as string[])
     .map((path) => path.replace(process.cwd(), ''))
     .filter((path) => /\.mdx?$/.test(path))
+    // Remove file extensions for page paths
+    .map((path) => path.replace(/\.mdx?$/, ''))
+    // Remove redundant docs prefix
+    .map((path) => path.replace(/[/\\]?docs/i, ''))
 
+/**
+ * Gets a list of all docs and their meta in the `DOCS_PATH` directory
+ */
 export async function getAllDocs() {
-  const files = (await recursiveReaddir(DOCS_PATH))
-    .filter((x) => x.indexOf('.mdx') > -1)
+  const files = ((await recursiveReaddir(DOCS_PATH)) as string[])
+    .filter((path) => /\.mdx?$/.test(path))
     .map((filePath) => {
-      const url = filePath.replace(process.cwd(), '').replace('.mdx', '').replace('/docs/', '')
+      const url = filePath
+        .replace(process.cwd(), '')
+        .replace('.mdx', '')
+        .replace(/[/\\]?docs/i, '')
       const source = fs.readFileSync(filePath)
       const { data } = matter(source)
 
       return {
         url,
-        title: data.title || url.split('/').pop().split('-').join(' '),
+        title: data.title || url.split(path.sep).pop().split('-').join(' '),
         nav: data.nav ?? Infinity,
       }
     })

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -11,8 +11,8 @@ export const DOCS_PATH = path.join(process.cwd(), 'docs')
 /**
  * Gets a list of all mdx files inside the `DOCS_PATH` directory
  */
-export const getDocsPaths = async () =>
-  ((await recursiveReaddir(DOCS_PATH)) as string[])
+export const getDocsPaths = async () => {
+  const paths = ((await recursiveReaddir(DOCS_PATH)) as string[])
     // Filter to only doc markdown
     .filter((path) => /\.mdx?$/.test(path))
     // Get local path
@@ -22,22 +22,25 @@ export const getDocsPaths = async () =>
     // Remove redundant docs prefix
     .map((path) => path.replace(/[/\\]?docs/i, ''))
 
+  return paths
+}
+
 /**
  * Gets a list of all docs and their meta in the `DOCS_PATH` directory
  */
-export async function getAllDocs() {
-  const files = (await getDocsPaths())
+export const getAllDocs = async () => {
+  const docs = (await getDocsPaths())
     .map((url) => {
       const source = fs.readFileSync(path.join(DOCS_PATH, `${url}.mdx`))
       const { data } = matter(source)
 
       return {
-        url,
+        url: url.replace(/[/\\]+/g, '/'),
         title: data.title || url.split(path.sep).pop().split('-').join(' '),
         nav: data.nav ?? Infinity,
       }
     })
     .sort((a, b) => (a.nav > b.nav ? 1 : -1))
 
-  return files
+  return docs
 }

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -13,8 +13,10 @@ export const DOCS_PATH = path.join(process.cwd(), 'docs')
  */
 export const getDocsPaths = async () =>
   ((await recursiveReaddir(DOCS_PATH)) as string[])
-    .map((path) => path.replace(process.cwd(), ''))
+    // Filter to only doc markdown
     .filter((path) => /\.mdx?$/.test(path))
+    // Get local path
+    .map((path) => path.replace(process.cwd(), ''))
     // Remove file extensions for page paths
     .map((path) => path.replace(/\.mdx?$/, ''))
     // Remove redundant docs prefix
@@ -24,14 +26,9 @@ export const getDocsPaths = async () =>
  * Gets a list of all docs and their meta in the `DOCS_PATH` directory
  */
 export async function getAllDocs() {
-  const files = ((await recursiveReaddir(DOCS_PATH)) as string[])
-    .filter((path) => /\.mdx?$/.test(path))
-    .map((filePath) => {
-      const url = filePath
-        .replace(process.cwd(), '')
-        .replace('.mdx', '')
-        .replace(/[/\\]?docs/i, '')
-      const source = fs.readFileSync(filePath)
+  const files = (await getDocsPaths())
+    .map((url) => {
+      const source = fs.readFileSync(path.join(DOCS_PATH, `${url}.mdx`))
       const { data } = matter(source)
 
       return {


### PR DESCRIPTION
This pull request addresses [the issues I found and shared on Discord](https://discord.com/channels/740090768164651008/810837017482362901/814986922241556480) with accessing and routing docs across machines.

I've cleaned up all the regex that touches paths to be agnostic to whichever OS you are on (see [`path.sep`](https://nodejs.org/api/path.html#path_path_sep)) and cleaned up that logic in the [`getDocsPaths`](https://github.com/CodyJasonBennett/website/blob/docs-path-fix/utils/mdxUtils.ts#L11-L21) method.