### PR TITLE
Docs: cleanup MDX, remark.

### DIFF
--- a/remark/withTableofContents.ts
+++ b/remark/withTableofContents.ts
@@ -1,0 +1,33 @@
+import slugify from '@sindresorhus/slugify'
+
+/**
+ * Generates a table of contents by parsing a node tree
+ * @param [toc] An array to push table contents to.
+ */
+const withTableofContents = (toc?: any[]) => {
+  return () => (tree) => {
+    // @ts-ignore
+    for (let i = 0; i < tree.children.length; i++) {
+      const node = tree.children[i]
+      if (node.type === 'heading' && [2, 3].includes(node.depth)) {
+        const title = node.children
+          .filter((n) => n.type === 'text')
+          .map((n) => n.value)
+          .join('')
+
+        const slug = slugify(title)
+
+        node.type = 'jsx'
+        node.value = `<Heading id={"${slug}"} level={${node.depth}}>${title}</Heading>`
+
+        if (Array.isArray(toc)) {
+          toc.push({ slug, title, depth: node.depth })
+        }
+      }
+    }
+
+    return tree
+  }
+}
+
+export default withTableofContents

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -48,7 +48,7 @@ export const getAllDocs = async () => {
 
       return {
         url,
-        title: data.title || pathname.replace('-', ' '),
+        title: data.title || pathname.replace(/\-/g, ' '),
         nav: data.nav ?? Infinity,
       }
     })

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -1,12 +1,17 @@
-import path from 'path'
-import fs from 'fs'
+import { join, sep } from 'path'
+import { readFileSync } from 'fs'
 import matter from 'gray-matter'
 import recursiveReaddir from 'recursive-readdir'
 
 /**
+ * Checks for the MDX file extension
+ */
+export const MARKDOWN_REGEX = /\.mdx?$/
+
+/**
  * Useful when you want to get the path to a specific file
  */
-export const DOCS_PATH = path.join(process.cwd(), 'docs')
+export const DOCS_PATH = join(process.cwd(), 'docs')
 
 /**
  * Gets a list of all mdx files inside the `DOCS_PATH` directory
@@ -14,13 +19,13 @@ export const DOCS_PATH = path.join(process.cwd(), 'docs')
 export const getDocsPaths = async () => {
   const paths = ((await recursiveReaddir(DOCS_PATH)) as string[])
     // Filter to only doc markdown
-    .filter((path) => /\.mdx?$/.test(path))
+    .filter((path) => MARKDOWN_REGEX.test(path))
     // Get local path
     .map((path) => path.replace(process.cwd(), ''))
     // Remove file extensions for page paths
-    .map((path) => path.replace(/\.mdx?$/, ''))
+    .map((path) => path.replace(MARKDOWN_REGEX, ''))
     // Remove redundant docs prefix
-    .map((path) => path.replace(/[\/\\]?docs/i, ''))
+    .map((path) => path.replace(`${sep}docs`, ''))
 
   return paths
 }
@@ -30,14 +35,19 @@ export const getDocsPaths = async () => {
  */
 export const getAllDocs = async () => {
   const docs = (await getDocsPaths())
-    .map((url) => {
-      const source = fs.readFileSync(path.join(DOCS_PATH, `${url}.mdx`))
+    .map((path) => {
+      // Get frontMatter from markdown
+      const source = readFileSync(join(DOCS_PATH, `${path}.mdx`))
       const { data } = matter(source)
 
-      const pathname = url.split(path.sep).pop()
+      // Normalize paths for web
+      const url = path.replace(/\\/g, '/')
+
+      // Get URL pathname
+      const pathname = url.split('/').pop()
 
       return {
-        url: url.replace(/\/|\\/g, '/'),
+        url,
         title: data.title || pathname.replace('-', ' '),
         nav: data.nav ?? Infinity,
       }

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -20,7 +20,7 @@ export const getDocsPaths = async () => {
     // Remove file extensions for page paths
     .map((path) => path.replace(/\.mdx?$/, ''))
     // Remove redundant docs prefix
-    .map((path) => path.replace(/[/\\]?docs/i, ''))
+    .map((path) => path.replace(/[\/\\]?docs/i, ''))
 
   return paths
 }
@@ -34,9 +34,11 @@ export const getAllDocs = async () => {
       const source = fs.readFileSync(path.join(DOCS_PATH, `${url}.mdx`))
       const { data } = matter(source)
 
+      const pathname = url.split(path.sep).pop()
+
       return {
-        url: url.replace(/[/\\]+/g, '/'),
-        title: data.title || url.split(path.sep).pop().split('-').join(' '),
+        url: url.replace(/\/|\\/g, '/'),
+        title: data.title || pathname.replace('-', ' '),
         nav: data.nav ?? Infinity,
       }
     })


### PR DESCRIPTION
Wraps up some housekeeping for the fix in #13.

Table of Contents generation was moved to the remark plugins folder, and the mdxUtils work a bit more explicitly. We can move any config or imports related to prism there as well.