### PR TITLE
Add scroll-margin-top to anchor targets in content

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -31,9 +31,15 @@
   }
 }
 
+.content-container :target {
+  /* <Search />'s h-16 + more spacing */
+  scroll-margin-top: theme('spacing.20');
+}
+
 .content-container ul > li {
   @apply my-2;
 }
+
 .content-container ul > li:before {
   content: '—';
   @apply inline-block mr-3 text-gray-300;


### PR DESCRIPTION
Currently when clicking on the anchors in TOC, i.e. `On this page`, the heading of the target is blocked by the search bar. This PR improves the UI by adding `scroll-margin-top` to anchor targets inside `.content-container`