### PR TITLE
Fix missing component name for Sandbox

### DIFF
--- a/components/Sandbox.tsx
+++ b/components/Sandbox.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-export default ({ id }) => {
+export default function Sandbox({ id }) {
   const [data, setData] = useState<{
     alias: string
     screenshot_url: string


### PR DESCRIPTION
This fixes the following warning: `Anonymous arrow functions cause Fast Refresh to not preserve local component state.`