### PR TITLE
docs: update license

### DIFF
--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Shu Ding
+Copyright (c) 2019-2021 Paul Henschel, pmndrs, all contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
> Continued from #63

I'm mirroring the license from react-spring ([the fixed ones](https://github.com/pmndrs/react-spring/pull/1480/files#diff-de9e7884e3b0ae3ca60f078e425c1a845fbd76f92adf3ffe8d95f3db7e498b08)), but there may be some things to review, like the use of present versus a range and who to attribute.