### PR TITLE
docs(jotai): Add documentation for useAtomsSnapshot and useGotoAtomsSnapshot

### DIFF
--- a/docs/jotai/api/devtools.mdx
+++ b/docs/jotai/api/devtools.mdx
@@ -66,22 +66,26 @@ Be careful using this hook because it will cause the component to re-render for 
 import { Provider } from 'jotai'
 import { useAtomsSnapshot } from 'jotai/devtools'
 
-const RegisteredAtoms: React.FC = () => {
+const RegisteredAtoms = () => {
   const atoms = useAtomsSnapshot()
 
   return (
-    <Provider>
+    <div>
+      <p>Atom count: {atoms.size}</p>
       <div>
-        <p>Atom count: {atoms.size}</p>
-        <div>
-          {Array.from(atoms).map(([atom, atomValue]) => (
-            <p key={`${atom}`}>{`${atom.debugLabel}: ${atomValue}`}</p>
-          ))}
-        </div>
+        {Array.from(atoms).map(([atom, atomValue]) => (
+          <p key={`${atom}`}>{`${atom.debugLabel}: ${atomValue}`}</p>
+        ))}
       </div>
-    </Provider>
+    </div>
   )
 }
+
+const App = () => (
+  <Provider>
+    <RegisteredAtoms />
+  </Provider>
+)
 ```
 
 ## useGotoAtomsSnapshot

--- a/docs/jotai/api/devtools.mdx
+++ b/docs/jotai/api/devtools.mdx
@@ -44,3 +44,84 @@ export const useTasksDevtools = () => {
   useAtomDevtools(tasksAtom, 'Tasks (Instance 2)')
 }
 ```
+
+## useAtomsSnapshot
+
+⚠️ Note: This hook only works in a `process.env.NODE_ENV !== 'production'` environment.
+
+`useAtomsSnapshot` takes a snapshot of the currently mounted atoms and their state.
+
+```ts
+function useAtomsSnapshot(scope?: Scope): AtomsSnapshot
+```
+
+It accepts an atom `scope` parameter and will return an `AtomsSnapshot`, which is basically a `Map<AnyAtom, unknown>`. You can use the `Map` API to iterate over atoms and their state.
+This hook is primarily meant for debugging and devtools use cases.
+
+Be careful using this hook because it will cause the component to re-render for all state changes.
+
+### Example
+
+```ts
+import { Provider } from 'jotai'
+import { useAtomsSnapshot } from 'jotai/devtools'
+
+const RegisteredAtoms: React.FC = () => {
+  const atoms = useAtomsSnapshot()
+
+  return (
+    <Provider>
+      <div>
+        <p>Atom count: {atoms.size}</p>
+        <div>
+          {Array.from(atoms).map(([atom, atomValue]) => (
+            <p key={`${atom}`}>{`${atom.debugLabel}: ${atomValue}`}</p>
+          ))}
+        </div>
+      </div>
+    </Provider>
+  )
+}
+```
+
+## useGotoAtomsSnapshot
+
+⚠️ Note: This hook only works in a `process.env.NODE_ENV !== 'production'` environment.
+
+`useGotoAtomsSnapshot` will update the current Jotai state to match the passed snapshot.
+
+```ts
+function useGotoAtomsSnapshot(
+  scope?: Scope
+): (values: Iterable<readonly [AnyAtom, unknown]>) => void
+```
+
+This hook returns a callback, which takes a `snapshot` from the `useAtomsSnapshot` hook and will update the Jotai state. It accepts an atom `scope` parameter and will error if the atoms have mixed scopes.
+This hook is primarily meant for debugging and devtools use cases.
+
+### Example
+
+```ts
+import { Provider } from 'jotai'
+import { useAtomsSnapshot, useGotoAtomsSnapshot } from 'jotai/devtools'
+
+const petAtom = atom('cat')
+const colorAtom = atom('blue')
+
+const UpdateSnapshot: React.FC = () => {
+  const snapshot = useAtomsSnapshot()
+  const goToSnapshot = useGotoAtomsSnapshot()
+  return (
+    <button
+      onClick={() => {
+        const newSnapshot = new Map(snapshot)
+        newSnapshot.set(petAtom, 'dog')
+        newSnapshot.set(colorAtom, 'green')
+        goToSnapshot(newSnapshot)
+      }}
+    >
+      Go to snapshot
+    </button>
+  )
+}
+```


### PR DESCRIPTION
This adds documentation for two new hooks in Jotai, which is meant for debugging and creation of devtools.