### PR TITLE
Fix: broken link to comparison page

### DIFF
--- a/docs/jotai/basics/concepts.mdx
+++ b/docs/jotai/basics/concepts.mdx
@@ -29,4 +29,4 @@ Jotai has two principles.
 
 Jotai's core API is minimalistic and allows building various utils based on it.
 
-Check out [comparison doc](/jotai/comparison) to see some differences with other libraries.
+Check out [comparison doc](/jotai/basics/comparison) to see some differences with other libraries.


### PR DESCRIPTION
broken link to comparison page

![image](https://user-images.githubusercontent.com/1951007/119155200-4b055c00-ba29-11eb-8a9f-d6cfc4823d30.png)
