### PR TITLE
docs(jotai): add atom-creators/atomWithToggle

### DIFF
--- a/docs/jotai/advanced-recipes/atom-creators.mdx
+++ b/docs/jotai/advanced-recipes/atom-creators.mdx
@@ -67,7 +67,7 @@ export function atomWithToggleAndStorage(
   initialValue?: boolean,
   storage?: any
 ): WritableAtom<boolean, boolean | undefined> {
-  const anAtom = atomWithStorage(key!, initialValue, storage!)
+  const anAtom = atomWithStorage(key, initialValue, storage!)
   const derivedAtom = atom(
     (get) => get(anAtom),
     (get, set, nextValue?: boolean) => {

--- a/docs/jotai/advanced-recipes/atom-creators.mdx
+++ b/docs/jotai/advanced-recipes/atom-creators.mdx
@@ -67,7 +67,7 @@ export function atomWithToggleAndStorage(
   initialValue?: boolean,
   storage?: any
 ): WritableAtom<boolean, boolean | undefined> {
-  const anAtom = atomWithStorage(key, initialValue, storage!)
+  const anAtom = atomWithStorage(key, initialValue, storage)
   const derivedAtom = atom(
     (get) => get(anAtom),
     (get, set, nextValue?: boolean) => {

--- a/docs/jotai/advanced-recipes/atom-creators.mdx
+++ b/docs/jotai/advanced-recipes/atom-creators.mdx
@@ -10,22 +10,20 @@ nav: 5.2
 This avoids the boilerplate of having to setup another atom just to update the state of the first.
 
 ```ts
-export function atomWithToggle(
-  initialValue?: boolean,
-  createAtom: (initialValue: boolean) => PrimitiveAtom<boolean> = atom
-): WritableAtom<boolean, boolean | undefined> {
-  const effectAtom = createAtom(initialValue || false)
-  const anAtom: any = atom(initialValue, (get, set, state?: boolean) => {
-    const update = state ?? !get(anAtom)
+import { WritableAtom, atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+
+export function atomWithToggle(initialValue?: boolean): WritableAtom<boolean, boolean | undefined> {
+  const anAtom = atom(initialValue, (get, set, nextValue?: boolean) => {
+    const update = nextValue ?? !get(anAtom)
     set(anAtom, update)
-    set(effectAtom, update)
   })
+
   return anAtom
 }
 ```
 
 An optional initial state can be provided as first argument.
-A second optional argument can be passed to provide an `atom creator` function, which could be used to enable composable behaviour with other `atom` utils. An example is described below, [`atomWithToggleStored`](#atomWithToggleStored).
 
 The setter function can have an optional arg to force a particular state (if you want to make a setActive function out of it for example).
 
@@ -54,29 +52,41 @@ const Toggle = () => {
 }
 ```
 
-## `atomWithToggleStored`
+## `atomWithToggleAndStorage`
 
-> `atomWithToggleStored` does the same as [`atomWithToggle`](#atomWithToggle) but also persist the state anytime it changes in given storage using [`atomWithStorage`](/jotai/api/utils#atomWithStorage).
+> `atomWithToggleAndStorage` does the same as [`atomWithToggle`](#atomWithToggle) but also persist the state anytime it changes in given storage using [`atomWithStorage`](/jotai/api/utils#atomWithStorage).
 
 Here is the source :
 
 ```ts
-export function atomWithToggleStored(
+import { WritableAtom, atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+
+export function atomWithToggleAndStorage(
   key: string,
   initialValue?: boolean,
   storage?: any
 ): WritableAtom<boolean, boolean | undefined> {
-  return atomWithToggle(initialValue, (initial) => atomWithStorage(key!, initial, storage))
+  const anAtom = atomWithStorage(key!, initialValue, storage!)
+  const derivedAtom = atom(
+    (get) => get(anAtom),
+    (get, set, nextValue?: boolean) => {
+      const update = nextValue ?? !get(anAtom)
+      set(anAtom, update)
+    }
+  )
+
+  return derivedAtom
 }
 ```
 
 And how it's used :
 
 ```ts
-import { atomWithToggleStored } from 'XXX'
+import { atomWithToggleAndStorage } from 'XXX'
 
 // will have an initial value set to false & be stored in localStorage under the key "isActive"
-const isActiveAtom = atomWithToggleStored('isActive')
+const isActiveAtom = atomWithToggleAndStorage('isActive')
 ```
 
 The usage in a component is also the same as [`atomWithToggle`](#atomWithToggle).

--- a/docs/jotai/advanced-recipes/atom-creators.mdx
+++ b/docs/jotai/advanced-recipes/atom-creators.mdx
@@ -1,0 +1,80 @@
+---
+title: Atom creators
+nav: 5.2
+---
+
+## `atomWithToggle`
+
+> `atomWithToggle` creates a new atom with a boolean as initial state & a setter function to toggle it.
+
+This avoid the boilerplate of having to setup another atom just to update the state of the first.
+
+```ts
+export function atomWithToggle(
+  initialValue?: boolean,
+  createAtom: (initialValue: boolean) => PrimitiveAtom<boolean> = atom
+): WritableAtom<boolean, boolean | undefined> {
+  const effectAtom = createAtom(initialValue || false)
+  const anAtom: any = atom(initialValue, (get, set, state?: boolean) => {
+    const update = state ?? !get(anAtom)
+    set(anAtom, update)
+    set(effectAtom, update)
+  })
+  return anAtom
+}
+```
+
+An optional initial state can be provided as first argument.
+The setter function can have an optional arg to force a particular state (if you want to make a setActive function out of it for example).
+
+Here is how it's used.
+
+```ts
+import { atomWithToggle } from 'XXX'
+
+// will defaults to true
+const isActiveAtom = atomWithToggle(true)
+```
+
+And in a component :
+
+```tsx
+const Toggle = () => {
+  const [isActive, toggle] = useAtom(isActiveAtom)
+
+  return (
+    <>
+      <button onClick={() => toggle()}>isActive: {isActive ? 'yes' : 'no'}</button>
+      <button onClick={() => toggle(true)}>force true</button>
+      <button onClick={() => toggle(false)}>force false</button>
+    </>
+  )
+}
+```
+
+## `atomWithToggleStored`
+
+> `atomWithToggleStored` does the same as [`atomWithToggle`](#atomWithToggle) but also persist the state anytime it changes in given storage using [`atomWithStorage`]('../api/utils#atomWithStorage').
+
+Here is the source :
+
+```ts
+export function atomWithToggleStored(
+  key: string,
+  initialValue?: boolean,
+  storage?: any
+): WritableAtom<boolean, boolean | undefined> {
+  return atomWithToggle(initialValue, (initial) => atomWithStorage(key!, initial, storage))
+}
+```
+
+And how it's used :
+
+```ts
+import { atomWithToggleStored } from 'XXX'
+
+// will defaults to false & be stored in localStorage under the key "isActive"
+const isActiveAtom = atomWithToggleStored('isActive')
+```
+
+The usage in a component is also the same as [`atomWithToggle`](#atomWithToggle).

--- a/docs/jotai/advanced-recipes/atom-creators.mdx
+++ b/docs/jotai/advanced-recipes/atom-creators.mdx
@@ -7,7 +7,7 @@ nav: 5.2
 
 > `atomWithToggle` creates a new atom with a boolean as initial state & a setter function to toggle it.
 
-This avoid the boilerplate of having to setup another atom just to update the state of the first.
+This avoids the boilerplate of having to setup another atom just to update the state of the first.
 
 ```ts
 export function atomWithToggle(
@@ -34,7 +34,7 @@ Here is how it's used.
 ```ts
 import { atomWithToggle } from 'XXX'
 
-// will defaults to true
+// will have an initial value set to true
 const isActiveAtom = atomWithToggle(true)
 ```
 
@@ -75,7 +75,7 @@ And how it's used :
 ```ts
 import { atomWithToggleStored } from 'XXX'
 
-// will defaults to false & be stored in localStorage under the key "isActive"
+// will have an initial value set to false & be stored in localStorage under the key "isActive"
 const isActiveAtom = atomWithToggleStored('isActive')
 ```
 

--- a/docs/jotai/advanced-recipes/atom-creators.mdx
+++ b/docs/jotai/advanced-recipes/atom-creators.mdx
@@ -25,6 +25,8 @@ export function atomWithToggle(
 ```
 
 An optional initial state can be provided as first argument.
+A second optional argument can be passed to provide an `atom creator` function, which could be used to enable composable behaviour with other `atom` utils. An example is described below, [`atomWithToggleStored`](#atomWithToggleStored).
+
 The setter function can have an optional arg to force a particular state (if you want to make a setActive function out of it for example).
 
 Here is how it's used.
@@ -54,7 +56,7 @@ const Toggle = () => {
 
 ## `atomWithToggleStored`
 
-> `atomWithToggleStored` does the same as [`atomWithToggle`](#atomWithToggle) but also persist the state anytime it changes in given storage using [`atomWithStorage`]('../api/utils#atomWithStorage').
+> `atomWithToggleStored` does the same as [`atomWithToggle`](#atomWithToggle) but also persist the state anytime it changes in given storage using [`atomWithStorage`](/jotai/api/utils#atomWithStorage).
 
 Here is the source :
 


### PR DESCRIPTION
This doc adds a page in `jotai` section `advanced-recipes` based on the outcome of the discussion of this PR https://github.com/pmndrs/jotai/pull/483 