### PR TITLE
Fix typos and formatting, consistent naming of three.js

### DIFF
--- a/docs/drei/abstractions/cubic-bezier-line.mdx
+++ b/docs/drei/abstractions/cubic-bezier-line.mdx
@@ -2,7 +2,7 @@
 title: CubicBezierLine
 ---
 
-Renders a [THREE.Line2](https://threejs.org/docs/#api/en/objects/Line) using THREE.CubicBezierCurve3 for interpolation.
+Renders a [`THREE.Line2`](https://threejs.org/docs/#api/en/objects/Line) using THREE.CubicBezierCurve3 for interpolation.
 
 ```jsx
 <CubicBezierLine

--- a/docs/drei/abstractions/line.mdx
+++ b/docs/drei/abstractions/line.mdx
@@ -2,7 +2,7 @@
 title: Line
 ---
 
-Renders a [THREE.Line2](https://threejs.org/docs/#api/en/objects/Line).
+Renders a [`THREE.Line2`](https://threejs.org/docs/#api/en/objects/Line).
 
 ```jsx
 <Line

--- a/docs/drei/abstractions/positional-audio.mdx
+++ b/docs/drei/abstractions/positional-audio.mdx
@@ -2,7 +2,7 @@
 title: PositionalAudio
 ---
 
-A wrapper around [THREE.PositionalAudio](https://threejs.org/docs/index.html#api/en/audio/PositionalAudio). Add this to groups or meshes to tie them to a sound that plays when the camera comes near.
+A wrapper around [`THREE.PositionalAudio`](https://threejs.org/docs/index.html#api/en/audio/PositionalAudio). Add this to groups or meshes to tie them to a sound that plays when the camera comes near.
 
 ```jsx
 <PositionalAudio

--- a/docs/drei/abstractions/quadratic-line.mdx
+++ b/docs/drei/abstractions/quadratic-line.mdx
@@ -2,7 +2,7 @@
 title: QuadraticBezierLine
 ---
 
-Renders a [THREE.Line2](https://threejs.org/docs/#api/en/objects/Line) using THREE.QuadraticBezierCurve3 for interpolation.
+Renders a [`THREE.Line2`](https://threejs.org/docs/#api/en/objects/Line) using THREE.QuadraticBezierCurve3 for interpolation.
 
 ```jsx
 <QuadraticBezierLine

--- a/docs/drei/cameras/cube-camera.mdx
+++ b/docs/drei/cameras/cube-camera.mdx
@@ -2,7 +2,7 @@
 title: CubeCamera
 ---
 
-A [THREE.CubeCamera](https://threejs.org/docs/index.html#api/en/cameras/CubeCamera) that returns its texture as a render-prop. It makes children invisible while rendering to the internal buffer so that they are not included in the reflection.
+A [`THREE.CubeCamera`](https://threejs.org/docs/index.html#api/en/cameras/CubeCamera) that returns its texture as a render-prop. It makes children invisible while rendering to the internal buffer so that they are not included in the reflection.
 
 Using the `frames` prop you can control if this camera renders indefinitively or statically (a given number of times).
 If you have two static objects in the scene, make it `frames={2}` for instance, so that both objects get to "see" one another in the reflections, which takes multiple renders.

--- a/docs/drei/controls/introduction.mdx
+++ b/docs/drei/controls/introduction.mdx
@@ -3,7 +3,7 @@ title: Introduction
 nav: 2
 ---
 
-If available controls have damping enabled by default, they manage their own updates, remove themselves on unmount, are compatible with the `invalidateFrameloop` canvas-flag. They inherit all props from their underlying [THREE controls](https://github.com/mrdoob/three.js/tree/dev/examples/jsm/controls).
+If available, controls have damping enabled by default. They manage their own updates, remove themselves on unmount, are compatible with the `invalidateFrameloop` canvas-flag. They inherit all props from their underlying [three.js controls](https://github.com/mrdoob/three.js/tree/dev/examples/jsm/controls).
 
 Every control component can be used with a custom camera using the `camera` prop:
 

--- a/docs/drei/controls/map-controls.mdx
+++ b/docs/drei/controls/map-controls.mdx
@@ -2,7 +2,7 @@
 title: MapControls
 ---
 
-Modifications to [THREE.TrackballControls](https://threejs.org/docs/?q=TrackballControls#examples/en/controls/TrackballControls), offering camera controls suitable for flat scenes — panning, zooming, and limited rotation.
+Modifications to [`THREE.TrackballControls`](https://threejs.org/docs/?q=TrackballControls#examples/en/controls/TrackballControls), offering camera controls suitable for flat scenes — panning, zooming, and limited rotation.
 
 ```jsx
 <MapControls />

--- a/docs/drei/performance/detailed.mdx
+++ b/docs/drei/performance/detailed.mdx
@@ -2,7 +2,7 @@
 title: Detailed
 ---
 
-A wrapper around [THREE.LOD](https://threejs.org/docs/index.html#api/en/objects/LOD) (Level of detail).
+A wrapper around [`THREE.LOD`](https://threejs.org/docs/index.html#api/en/objects/LOD) (Level of detail).
 
 ```jsx
 <Detailed

--- a/docs/drei/shaders/shader-material.mdx
+++ b/docs/drei/shaders/shader-material.mdx
@@ -2,10 +2,10 @@
 title: shaderMaterial
 ---
 
-Creates a [THREE.ShaderMaterial](https://threejs.org/docs/?q=ShaderMaterial#api/en/materials/ShaderMaterial) for you with easier handling of uniforms, which are also automatically declared as setter/getters on the object.
+Creates a [`THREE.ShaderMaterial`](https://threejs.org/docs/?q=ShaderMaterial#api/en/materials/ShaderMaterial) for you with easier handling of uniforms, which are also automatically declared as setter/getters on the object.
 
 ```jsx
-import { extend } from 'react-three-fiber'
+import { extend } from '@react-three/fiber'
 import glsl from 'babel-plugin-glsl/macro'
 
 const ColorShiftMaterial = shaderMaterial(

--- a/docs/react-three-fiber/API/canvas.mdx
+++ b/docs/react-three-fiber/API/canvas.mdx
@@ -25,19 +25,19 @@ The props available for the canvas are:
 
 | Prop            | Description                                                        | Default                                                  |
 | --------------- | ------------------------------------------------------------------ | -------------------------------------------------------- |
-| children        | Threejs jsx elements or regular components                         |                                                          |
+| children        | three.js JSX elements or regular components                         |                                                          |
 | gl              | Props that go into the default renderer, or your own renderer      | `{}`                                                     |
-| camera          | Props that go into the default camera, or your own THREE.Camera    | `{ fov: 75, near: 0.1, far: 1000, position: [0, 0, 5] }` |
-| shadows         | Props that go into gl.shadowMap, can also be set true for PCFsoft  | `false`                                                  |
+| camera          | Props that go into the default camera, or your own `THREE.Camera`  | `{ fov: 75, near: 0.1, far: 1000, position: [0, 0, 5] }` |
+| shadows         | Props that go into `gl.shadowMap`, can also be set true for `PCFsoft`  | `false`                                                  |
 | raycaster       | Props that go into the default raycaster                           | `{}`                                                     |
-| vr              | Switches renderer to VR mode, then uses gl.setAnimationLoop        | `false`                                                  |
+| vr              | Switches renderer to VR mode, then uses `gl.setAnimationLoop`        | `false`                                                  |
 | mode            | React mode: legacy, blocking, concurrent                           | `blocking`                                               |
 | frameloop       | Render mode: always, demand, never                                 | `always`                                                 |
 | resize          | Resize config, see react-use-measure's options                     | `{ scroll: true, debounce: { scroll: 50, resize: 0 } }`  |
 | orthographic    | Creates an orthographic camera                                     | `false`                                                  |
-| dpr             | Pixel-ratio, use window.devicePixelRatio, or automatic: [min, max] | `undefined`                                              |
+| dpr             | Pixel-ratio, use `window.devicePixelRatio`, or automatic: [min, max] | `undefined`                                              |
 | linear          | Switch off automatic sRGB encoding and gamma correction            | `false`                                                  |
-| flat            | Use THREE.NoToneMapping instead of THREE.ACESFilmicToneMapping     | `false`                                                  |
+| flat            | Use `THREE.NoToneMapping` instead of `THREE.ACESFilmicToneMapping` | `false`                                                  |
 | onCreated       | Callback after the canvas has rendered (but not yet committed)     | `(state) => {}`                                          |
 | onPointerMissed | Response for pointer clicks that have missed any target            | `(event) => {}`                                          |
 
@@ -50,22 +50,22 @@ set({ frameloop: 'demand' })
 
 ### Defaults that the canvas component sets up
 
-Canvas will create a translucent THREE.WebGLRenderer with the following properties:
+Canvas will create a translucent `THREE.WebGLRenderer` with the following properties:
 
 - antialias=true
 - alpha=true
 - powerPreference="high-performance"
 - setClearAlpha(0)
-- A THREE.Perspective camera
-- A THREE.Orthographic cam if `orthographic` is true
-- A THREE.PCFSoftShadowMap if `shadowMap` is true
-- A THREE.Scene (into which all the JSX is rendered) and a THREE.Raycaster
+- A `THREE.Perspective` camera
+- A `THREE.Orthographic` cam if `orthographic` is true
+- A `THREE.PCFSoftShadowMap` if `shadowMap` is true
+- A `THREE.Scene` (into which all the JSX is rendered) and a `THREE.Raycaster`
 - A [resize observer](https://github.com/react-spring/react-use-measure)
 
 <Hint>
   The colorspace will be set to sRGB (unless "linear" is true), all colors and textures will be
-  auto-converted. Consult https://www.donmccurdy.com/2020/06/17/color-management-in-threejs for more
-  information about this. Unless "flat" is true it will set up THREE.ACESFilmicToneMapping for
+  auto-converted. Consult [donmccurdy.com: Color Management in three.js](https://www.donmccurdy.com/2020/06/17/color-management-in-threejs) for more
+  information about this. Unless "flat" is true it will set up `THREE.ACESFilmicToneMapping` for
   slightly more contrast.
 </Hint>
 

--- a/docs/react-three-fiber/API/events.mdx
+++ b/docs/react-three-fiber/API/events.mdx
@@ -77,7 +77,7 @@ even if you don't want this object to respond to the pointer event. If you do wa
 
 ### Pointer capture
 
-Because events go to all intersected objects, capturing the pointer also works differently. In the DOM, the capturing object **replaces** the hit test, but in React-Three-Fiber, the capturing object is **added** to the hit test result: if the capturing object was not hit, then all of the hit objects (and their ancestors) get the event first, followed by the capturing object and its ancestors. The capturing object can also use `event.stopPropagation()` so that objects that really were hit get pointerout events.
+Because events go to all intersected objects, capturing the pointer also works differently. In the DOM, the capturing object **replaces** the hit test, but in react-three-fiber, the capturing object is **added** to the hit test result: if the capturing object was not hit, then all of the hit objects (and their ancestors) get the event first, followed by the capturing object and its ancestors. The capturing object can also use `event.stopPropagation()` so that objects that really were hit get pointerout events.
 
 Note that you can access the `setPointerCapture` and `releasePointerCapture` methods **only** via `event.target`: they don't get added to the `Object3D` instances in the scene graph.
 

--- a/docs/react-three-fiber/API/hooks.mdx
+++ b/docs/react-three-fiber/API/hooks.mdx
@@ -4,7 +4,7 @@ description: Hooks are the heart of react-three-fiber
 nav: 11
 ---
 
-Hooks allow your to tie or request specific information to your component. For instance components that want to participate in the renderloop use can do so with `useFrame`, components that need to be informed of threejs specifics use `useThree` and so on. All hooks clean up after themselves once the component unmounts.
+Hooks allow your to tie or request specific information to your component. For instance, components that want to participate in the renderloop use can do so with `useFrame`, components that need to be informed of three.js specifics use `useThree` and so on. All hooks clean up after themselves once the component unmounts.
 
 <Hint>Hooks can only be used inside the Canvas element because they rely on context!</Hint>
 
@@ -60,11 +60,11 @@ The hook is reactive, if you resize the browser for instance, you get fresh meas
 | frameloop       | React render-mode                                         | `always`, `demand`, `never`                                                                                                                                                                                    |
 | performance     | System regression                                         | `{ current: number, min: number, max: number, debounce: number, regress: () => void }`                                                                                                                         |
 | size            | Canvas size in pixels                                     | `{ width: number, height: number }`                                                                                                                                                                            |
-| viewport        | Viewport size in Threejs units                            | `{ width: number, height: number, initialDpr: number, dpr: number, factor: number, distance: number, aspect: number, getCurrentViewport: (camera?: Camera, target?: THREE.Vector3, size?: Size) => Viewport }` |
+| viewport        | Viewport size in three.js units                            | `{ width: number, height: number, initialDpr: number, dpr: number, factor: number, distance: number, aspect: number, getCurrentViewport: (camera?: Camera, target?: THREE.Vector3, size?: Size) => Viewport }` |
 | get             | Allows you to set any state property                      | `() => GetState<RootState>`                                                                                                                                                                                    |
 | set             | Allows you to retrieve any state property non-rteactively | `(state: SetState<RootState>) => void`                                                                                                                                                                         |
-| invalidate      | Request a new render, given that frameloop === 'demand'   | `() => void`                                                                                                                                                                                                   |
-| advance         | Advance one tick, given that frameloop === 'never'        | `(timestamp: number, runGlobalEffects?: boolean) => void`                                                                                                                                                      |
+| invalidate      | Request a new render, given that `frameloop === 'demand'` | `() => void`                                                                                                                                                                                                   |
+| advance         | Advance one tick, given that `frameloop === 'never'`      | `(timestamp: number, runGlobalEffects?: boolean) => void`                                                                                                                                                      |
 | setSize         | Resize the canvas                                         | `(width: number, height: number) => void`                                                                                                                                                                      |
 | setDpr          | Set the pixel-ratio                                       | `(dpr: number) => void`                                                                                                                                                                                        |
 | onPointerMissed | Response for pointer clicks that have missed a target     | `() => void`                                                                                                                                                                                                   |
@@ -72,14 +72,14 @@ The hook is reactive, if you resize the browser for instance, you get fresh meas
 
 ### Selector
 
-You can also select properties, this allows you to avoid needless re-render for components that are interested only in particulars. Reactivity does not include deeper threejs internals!
+You can also select properties, this allows you to avoid needless re-render for components that are interested only in particulars. Reactivity does not include deeper three.js internals!
 
 ```jsx
 // Will only trigger re-render when the default camera is exchanged
 const camera = useThree((state) => state.camera)
 // Will only re-render on resize changes
 const viewport = useThree((state) => state.viewport)
-// ❌ You cannot expect reactivity from Threejs internals!
+// ❌ You cannot expect reactivity from three.js internals!
 const zoom = useThree((state) => state.camera.zoom)
 ```
 
@@ -105,7 +105,7 @@ function Foo() {
 
 ## useFrame
 
-This hook allows you to execute code on every rendered frame, like running effects, updating controls, and so on. You receive the state (same as `useThree`) and a clock delta. Your callback function will be invoked just before a frame is rendered. When the component unmounts it is un-subscribed automatically from the render-loop.
+This hook allows you to execute code on every rendered frame, like running effects, updating controls, and so on. You receive the state (same as `useThree`) and a clock delta. Your callback function will be invoked just before a frame is rendered. When the component unmounts it is unsubscribed automatically from the render-loop.
 
 ```jsx
 import { useFrame } from '@react-three/fiber'
@@ -139,7 +139,7 @@ useFrame(({ gl, scene, camera }) => {
 
 ## useLoader
 
-This hook loads assets and suspends for easier fallback- and error-handling. It can take any loader as its first argument: GLTFLoader, OBJLoader, TextureLoader, FontLoader, etc. It is based on [React.Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html), so fallback-handling and [error-handling](https://reactjs.org/docs/error-boundaries.html) happen at the parental level.
+This hook loads assets and suspends for easier fallback- and error-handling. It can take any three.js loader as its first argument: GLTFLoader, OBJLoader, TextureLoader, FontLoader, etc. It is based on [React.Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html), so fallback-handling and [error-handling](https://reactjs.org/docs/error-boundaries.html) happen at the parental level.
 
 ```jsx
 import { Suspense } from 'react'
@@ -154,7 +154,7 @@ function Model() {
 }
 
 function App() {
-  ;<Suspense fallback={<FallbackComponent /> /* or null */}>
+  <Suspense fallback={<FallbackComponent /> /* or null */}>
     <Model />
   </Suspense>
 }
@@ -172,7 +172,7 @@ function App() {
 
 ### Loader extensions
 
-You can provide a callback as trhe third argument if you need to configure your loader:
+You can provide a callback as the third argument if you need to configure your loader:
 
 ```jsx
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
@@ -204,7 +204,7 @@ useLoader(loader, url, extensions, xhr => {
 
 ### Special treatment of GLTFLoaders and all loaders that return a scene prop
 
-If a `result.scene` prop is found the hook will automatically create a object & material collection: `{ nodes, materials }`. This lets you build immutable scene graphs selectively. You can also specifically alter the data without having to traverse it. The [gltfjsx](https://github.com/pmndrs/gltfjsx) specifically relies on this data.
+If a `result.scene` prop is found the hook will automatically create a object & material collection: `{ nodes, materials }`. This lets you build immutable scene graphs selectively. You can also specifically alter the data without having to traverse it. [gltfjsx](https://github.com/pmndrs/gltfjsx) specifically relies on this data.
 
 ```jsx
 const { nodes, material } = useLoader(GLTFLoader, url)
@@ -220,7 +220,7 @@ useLoader.preload(GLTFLoader, '/model.glb' /* extensions */)
 
 ## useGraph
 
-Convenience hook which creates a memoized, named object/material collection from any Object3D.
+Convenience hook which creates a memoized, named object/material collection from any [`Object3D`](https://threejs.org/docs/#api/en/core/Object3D).
 
 ```jsx
 import { useLoader } from '@react-three/fiber'

--- a/docs/react-three-fiber/API/objects.mdx
+++ b/docs/react-three-fiber/API/objects.mdx
@@ -30,7 +30,7 @@ You can use [three.js's entire object catalogue and all properties](https://thre
 
 ### Constructor arguments
 
-In `three.js` objects are classes that are instantiated. These classes can receive one-time constructor arguments (`new THREE.SphereGeometry(1, 32)`), and properties (`someObject.visible = true`). In three-fiber constructor arguments are always passed as an array via `args`. If args change later on, the object must naturally get re-constructed from scratch!
+In three.js objects are classes that are instantiated. These classes can receive one-time constructor arguments (`new THREE.SphereGeometry(1, 32)`), and properties (`someObject.visible = true`). In react-three-fiber, constructor arguments are always passed as an array via `args`. If args change later on, the object must naturally get reconstructed from scratch!
 
 ```jsx
 <sphereGeometry args={[1, 32]} />
@@ -38,14 +38,14 @@ In `three.js` objects are classes that are instantiated. These classes can recei
 
 ### Shortcuts
 
-All properties whose underlying object has a `.set()` method can directly receive the same arguments that `set` would otherwise take. For example [THREE.Color.set](https://threejs.org/docs/index.html#api/en/math/Color.set) can take a color string, so instead of `color={new THREE.Color('hotpink')}` you can simply write `color="hotpink"`. Some `set` methods take multiple arguments, for instance [THREE.Vector3](https://threejs.org/docs/index.html#api/en/math/Vector3.set), give it an array in that case `position={[100, 0, 0]}`.
+All properties whose underlying object has a `.set()` method can directly receive the same arguments that `set` would otherwise take. For example [`THREE.Color.set`](https://threejs.org/docs/index.html#api/en/math/Color.set) can take a color string, so instead of `color={new THREE.Color('hotpink')}` you can simply write `color="hotpink"`. Some `set` methods take multiple arguments, for instance [`THREE.Vector3`](https://threejs.org/docs/index.html#api/en/math/Vector3.set), give it an array in that case `position={[100, 0, 0]}`.
 
 ```jsx
 <mesh position={[1, 2, 3]} />
   <meshStandardMaterial color="hotpink" />
 ```
 
-Properties that have a `setScalar` method (for instance Vector3) can be set like so:
+Properties that have a `setScalar` method (for instance `Vector3`) can be set like so:
 
 ```jsx
 // Translates to <mesh scale={[1, 1, 1]} />
@@ -81,7 +81,7 @@ Sometimes attaching isn't enough. For example, the following example attaches ef
   <glitchPass attachArray="passes" renderToScreen />
 ```
 
-You can also attach to named parent properties using `attachObject={[target, name]}`, which adds the object and takes it out on unmount. The following adds a buffer-attribute to parent.attributes.position.
+You can also attach to named parent properties using `attachObject={[target, name]}`, which adds the object and takes it out on unmount. The following adds a buffer-attribute to `parent.attributes.position`.
 
 ```jsx
 <bufferGeometry attach="geometry">
@@ -110,7 +110,7 @@ If you want to reach into nested attributes (for instance: `mesh.rotation.x`), j
 
 ### Putting already existing objects into the scene-graph
 
-You can use the `primitive` placeholder for that. You can still give it properties or attach nodes to it. Never add the same object multiple times, this is not allowed in `three.js`! Primitives will not dispose of the object they carry on unmount, you are responsible for disposing of it!
+You can use the `primitive` placeholder for that. You can still give it properties or attach nodes to it. Never add the same object multiple times, this is not allowed in three.js! Primitives will not dispose of the object they carry on unmount, you are responsible for disposing of it!
 
 ```jsx
 const mesh = new THREE.Mesh(geometry, material)

--- a/docs/react-three-fiber/advanced/how-it-works.mdx
+++ b/docs/react-three-fiber/advanced/how-it-works.mdx
@@ -30,7 +30,7 @@ function MyApp() {
 }
 ```
 
-This is equivalent, in THREE, to:
+In three.js, this is equivalent to:
 
 ```js
 import * as THREE from 'three'
@@ -80,7 +80,7 @@ Object creation is handled transparently by the Fiber renderer, the name of the 
 
 ## The `attach` props
 
-Fiber always tries to correctly estimate the relationship between components and their parents, for example:
+Fiber always tries to correctly infer the relationship between components and their parents, for example:
 
 ```jsx
 <group>
@@ -94,7 +94,7 @@ Here, we always know that a group can only have children, so Fiber just calls th
 group.add(mesh)
 ```
 
-For meshes and other THREE objects, rules can be different. Looking at the three.js documentation, we can see how a `THREE.Mesh` object is constructed using a `material` and a `geometry`.
+For meshes and other three.js objects, rules can be different. Looking at the three.js documentation, we can see how a `THREE.Mesh` object is constructed using a `material` and a `geometry`.
 
 With the `attach` prop, we can precisely tell the renderer what property to attach each component to:
 
@@ -112,7 +112,7 @@ mesh.material = new THREE.MeshNormalMaterial()
 mesh.geometry = new THREE.BoxBufferGeometry()
 ```
 
-As you can see, the `attach` prop is telling Fiber to set the parent's "material" property to a reference to our `<meshNormalMaterial />` object.
+As you can see, the `attach` prop is telling Fiber to set the parent's `material` property to a reference to our `<meshNormalMaterial />` object.
 
 <Callout>
   Note that while we used geometry and material for this example, Fiber also infers the attach
@@ -126,7 +126,7 @@ _Add example_
 
 ## Props
 
-With Fiber, you can pass any THREE property as a React property, and it will be assigned to the constructed object:
+With Fiber, you can pass any three.js property as a React property, and it will be assigned to the constructed object:
 
 ```jsx
 <meshBasicMaterial color="red" />
@@ -164,7 +164,7 @@ mesh.scale.set(3, 4, 5)
 
 [Pointer Events](/docs/events) are transparently handled by Fiber. On startup, it will create a [raycaster](https://threejs.org/docs/#api/en/core/Raycaster) for mouse picking.
 
-Every object wih `onPointer*` props, will be added to the array of objects checked every frame by the raycaster:
+Every object wih `onPointer` props will be added to the array of objects checked every frame by the raycaster:
 
 ```jsx
 <mesh onPointerDown={console.log}>...</mesh>
@@ -189,10 +189,10 @@ By default, Fiber will setup a render loop that renders the default `scene` from
 
 The loop is setup using [setAnimationLoop](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.setAnimationLoop), which will execute its callback every time a new frame is renderable. This is what will happen every render:
 
-1. all [global before effects](docs/recipes/effects) are executed
-2. clock [delta](docs/time) is saved - implying all `useFrame` calls will share the same `delta`
+1. All [global before effects](docs/recipes/effects) are executed
+2. Clock [delta](docs/time) is saved - implying all `useFrame` calls will share the same `delta`
 3. `useFrame` callbacks are executed in order
 4. `renderer.render(scene, camera)` is called, effectively rendering the scene to screen
-5. all [global after effects](docs/recipes/effects) are executed
+5. All [global after effects](docs/recipes/effects) are executed
 
 _Add about opting out of render_

--- a/docs/react-three-fiber/advanced/pitfalls.mdx
+++ b/docs/react-three-fiber/advanced/pitfalls.mdx
@@ -8,7 +8,7 @@ nav: 14
 
 This is a good overview: https://discoverthreejs.com/tips-and-tricks
 
-The most important gotcha in Threejs is that creating objects can be expensive, think twice before you mount/unmnount things! Every material or light that you put into the scene has to compile, every geometry you create will be processed. Share materials and geometries if you can, either in global scope or locally:
+The most important gotcha in three.js is that creating objects can be expensive, think twice before you mount/unmnount things! Every material or light that you put into the scene has to compile, every geometry you create will be processed. Share materials and geometries if you can, either in global scope or locally:
 
 ```jsx
 const geom = useMemo(() => new BoxBufferGeometry(), [])
@@ -109,7 +109,7 @@ return <mesh ref={ref} />
 
 ## Don't mount indiscriminately
 
-In Threejs it is very common to not re-mount at all, see the ["disposing of things"](https://discoverthreejs.com/tips-and-tricks/) section in discover-three. This is because materials get re-compiled, etc.
+In three.js it is very common to not re-mount at all, see the ["disposing of things"](https://discoverthreejs.com/tips-and-tricks/) section in discover-three. This is because materials get re-compiled, etc.
 
 ### ✅ Use concurrent mode
 
@@ -146,7 +146,7 @@ useFrame(() => {
 
 ## useLoader instead of plain loaders
 
-Threejs loaders give you the ability to load async assets (models, textures, etc), but they are probablic.
+three.js loaders give you the ability to load async assets (models, textures, etc), but they are probablic.
 
 ### ❌ No re-use is bad for perf
 

--- a/docs/react-three-fiber/getting-started/basic-animations.mdx
+++ b/docs/react-three-fiber/getting-started/basic-animations.mdx
@@ -6,7 +6,7 @@ nav: 6
 
 This tutorial will assume some React knowledge, and will be based on [this starter codesandbox](https://codesandbox.io/s/getting-started-01-12q81?from-embed), so just fork it and follow along!
 
-We will build a really small, continuos animation loop, that will be the basic building block of more advanced animations later on.
+We will build a really small, continuous animation loop, that will be the basic building block of more advanced animations later on.
 
 ## useFrame
 
@@ -41,11 +41,11 @@ useFrame(({ clock }) => {
 })
 ```
 
-`clock` is a [THREE.js Clock](https://threejs.org/docs/#api/en/core/Clock) object, from which we are getting the total elapsed time, which will be key for our animations.
+`clock` is a [three.js Clock](https://threejs.org/docs/#api/en/core/Clock) object, from which we are getting the total elapsed time, which will be key for our animations.
 
 ## Animating with Refs
 
-It would be tempting to just update the state of our component via `setState` and let it change the `mesh` via props, but going through state isn't ideal, when dealing with continuos updates, commonly know as [transient updates]().
+It would be tempting to just update the state of our component via `setState` and let it change the `mesh` via props, but going through state isn't ideal, when dealing with continuous updates, commonly know as [transient updates]().
 Instead, we want to **directly mutate our mesh each frame**. First, we'll have to get a `reference` to it, via the `useRef` React hook:
 
 ```jsx
@@ -62,7 +62,7 @@ function MyAnimatedBox() {
 }
 ```
 
-myMesh will now hold a reference to the actual THREE.js object, which we can now freely mutate in `useFrame`, without having to worry about React:
+`myMesh` will now hold a reference to the actual three.js object, which we can now freely mutate in `useFrame`, without having to worry about React:
 
 ```jsx
 useFrame(({ clock }) => {

--- a/docs/react-three-fiber/getting-started/events-and-interaction.mdx
+++ b/docs/react-three-fiber/getting-started/events-and-interaction.mdx
@@ -10,7 +10,7 @@ After we have our continuous loop running the next step would be to allow our me
 
 ## User Interaction
 
-Any mesh in react three fiber has a big number of events, 13 to be more precise:
+Any mesh in React Three Fiber has a large number of events, 13 to be more precise:
 
 ```jsx
 <mesh

--- a/docs/react-three-fiber/getting-started/installation.mdx
+++ b/docs/react-three-fiber/getting-started/installation.mdx
@@ -25,7 +25,7 @@ If you just want to give it a try, fork this [example on codesandbox](https://co
 
 ## Next.js
 
-It should work ootb but you will encounter untranspiled add-ons in the Three.js exo system, in that case you can install the `next-transpile-modules` module:
+It should work out of the box but you will encounter untranspiled add-ons in the three.js ecosystem, in that case you can install the `next-transpile-modules` module:
 
 ```bash
 npm install next-transpile-modules --save-dev
@@ -42,7 +42,7 @@ Make sure to check out our [official next.js starter](https://github.com/pmndrs/
 
 ## Without build tools
 
-You can use Fiber with browser-ready ES Modules from [skypack.dev](https://skypack.dev) and a JSX-like syntax powered by [htm](https://github.com/developit/htm).
+You can use react-three-fiber with browser-ready ES Modules from [skypack.dev](https://skypack.dev) and a JSX-like syntax powered by [htm](https://github.com/developit/htm).
 
 ```jsx
 import ReactDOM from 'https://cdn.skypack.dev/react-dom'

--- a/docs/react-three-fiber/getting-started/loading-models.mdx
+++ b/docs/react-three-fiber/getting-started/loading-models.mdx
@@ -42,7 +42,7 @@ You can play with the sandbox and see how it looks here after I added an HDRI ba
 
 Here comes the really fancy part, you can transform these models into React components and then use them as your would any React component.
 
-To do this grab your `GLTF` model and head over to [https://gltf.pmnd.rs/](https://gltf.pmnd.rs/) and drop your `GLTF`, after that you should see something like:
+To do this, grab your `GLTF` model and head over to [https://gltf.pmnd.rs/](gltf.pmnd.rs) and drop your `GLTF`, after that you should see something like:
 
 ![gltfjsx](./gltfjsx.png)
 
@@ -80,7 +80,7 @@ export default function Model(props) {
 useGLTF.preload('/Poimandres.gltf')
 ```
 
-Now we can import our model like we would import any react component and use it in our app:
+Now we can import our model like we would import any React component and use it in our app:
 
 ```jsx
 import { Suspense } from 'react'
@@ -109,7 +109,7 @@ You can play with the sandbox here:
 
 ## Loading OBJ models
 
-In the case we will use the trusted `useLoader` but in combination with `three.js` `OBJLoader`.
+In this case, we will use the trusted `useLoader` hook but in combination with `three.js` `OBJLoader`.
 
 ```js
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader'
@@ -140,7 +140,7 @@ import { useLoader } from '@react-three/fiber'
 import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader'
 ```
 
-To create our scene we can get the fbx as a return value of the useLoader by passing the `FBX` loader and the location of our file like so:
+To create our scene we can get the fbx as a return value of the useLoader by passing the `FBXloader` and the location of our file like so:
 
 ```jsx
 function Scene() {
@@ -170,12 +170,12 @@ You can play with the sandbox here:
 
 ## Showing a loader
 
-If your model is big it's always good to show a small loader of how much is already is loaded and again [@react-three/drei](https://github.com/pmndrs/drei) is here to help with `Html` and `useProgress`.
+If your model is big and takes a while to load, it's always good to show a small loader of how much is already is loaded and again [@react-three/drei](https://github.com/pmndrs/drei) is here to help with `Html` and `useProgress`.
 
 - `Html` allows you place plain ol' HTML in your canvas and render it like you would a normal DOM element.
 - `useProgress` is a hook that gives you a bunch of information about the loading status of your model.
 
-With these two things we can create a very bane bones loading component like so:
+With these two things we can create a very barebones loading component like so:
 
 ```jsx
 import { Html, useProgress } from '@react-three/drei'
@@ -186,7 +186,7 @@ function Loader() {
 }
 ```
 
-We can then wrap our model in it using suspense like so:
+We can then wrap our model in it using `Suspense` like so:
 
 ```jsx
 export default function App() {
@@ -200,6 +200,6 @@ export default function App() {
 }
 ```
 
-The hook returns much more than just the progress so there is a lot you can do there to give the user more information about the loading status of the application, you can play with all of them in this sandbox:
+The hook returns much more than just the progress so there is a lot you can do there to give the user more information about the loading status of the application. You can play with all of them in this sandbox:
 
 <Codesandbox id="nn2m7" />

--- a/docs/react-three-fiber/getting-started/loading-textures.mdx
+++ b/docs/react-three-fiber/getting-started/loading-textures.mdx
@@ -8,7 +8,7 @@ nav: 5
 
 ## Using TextureLoader & useLoader
 
-To load the textures we will use the `TextureLoader` from ThreeJS in combination with `useLoader` that will allow us to pass the location of the texture and get the map back.
+To load the textures we will use the `TextureLoader` from three.js in combination with `useLoader` that will allow us to pass the location of the texture and get the map back.
 
 It's better to explain with code, let's say you downloaded [this texture](https://cc0textures.com/view?id=PavingStones092) and placed it in the public folder of your site, to get the color map from it you could do:
 
@@ -50,7 +50,7 @@ export default function App() {
 }
 ```
 
-If everything went according to plan you should now be able top apply this texture to the sphere like so:
+If everything went according to plan, you should now be able to apply this texture to the sphere like so:
 
 ```jsx
 <sphereGeometry args={[1, 100, 100]} map={colorMap} />
@@ -82,7 +82,7 @@ Now we can place them in our mesh like so:
 />
 ```
 
-The displacement will probably be too much so usually setting it to 0.2 will make it look good. Our final code would look something like:
+The displacement will probably be too much, usually setting it to 0.2 will make it look good. Our final code would look something like:
 
 ```jsx
 function Scene() {
@@ -113,7 +113,7 @@ const [colorMap, displacementMap, normalMap, roughnessMap, aoMap] = useLoader(Te
 
 ## Using useTexture
 
-Another way to import these is using `useTexture` from [`@react-three/drei`](https://github.com/pmndrs/drei), that will make it slightly easier and there is no need to import the TextureLoader, our code would like so:
+Another way to import these is using `useTexture` from [`@react-three/drei`](https://github.com/pmndrs/drei), that will make it slightly easier and there is no need to import the `TextureLoader`, our code would look like:
 
 ```js
 import { useTexture } from "@react-three/drei";

--- a/docs/react-three-fiber/getting-started/using-with-react-spring.mdx
+++ b/docs/react-three-fiber/getting-started/using-with-react-spring.mdx
@@ -8,7 +8,7 @@ This tutorial will assume some React knowledge, and will be based on [this start
 
 We learned out to create small animations and also how to react to user interaction but we did not learn yet how to change these props in a way it creates an animation.
 
-For that we are gonna use `react-spring`, `react-spring` is spring physics based animation library and it works perfectly with React Three Fiber as it comes from the same maintainers and it also has exports created specifically for working with React Three Fiber.
+For that we are gonna use `react-spring`, `react-spring` is spring physics based animation library and it works perfectly with React Three Fiber as it comes from the same maintainers and it also has exports created specifically for use with React Three Fiber.
 
 ## Spring Animations
 
@@ -18,7 +18,7 @@ Let's start by defining some concepts about `react-spring` as it works with anim
 transition: opacity 200ms ease;
 ```
 
-This is not how `react-spring` works, it instead works with `springs` and what that means is that how the animations flows depends on things like the mass, tension and friction of what you want to animate and this exactly what makes it so perfect to use with 3D.
+This is not how `react-spring` works, it instead works with `springs` and what that means is that how the animations flows depends on things like the mass, tension and friction of what you want to animate and this is exactly what makes it so perfect to use with 3D.
 
 ## Using `react-spring`
 
@@ -28,7 +28,7 @@ Let's start by installing it:
 npm install three @react-spring/three
 ```
 
-After that we will importing everything from `react-spring/three` as that is the components that were created specifically for React Three Fiber.
+After that we will importing everything from `react-spring/three` as it contains the components that were created specifically for use with React Three Fiber.
 
 We will need to import two things from `react-spring`:
 
@@ -68,7 +68,7 @@ Now that we have this animated value let's place it in our mesh:
 
 If you now click on the cube you can see that it doesn't just jump from one value to the other but instead it animates smoothly between the two values.
 
-One last touch I want to do is add a bit of wobblier effect to the animation and for that we can import the config from `react-spring`:
+One last touch I want to do is add is a bit of a wobblier effect to the animation and for that we can import the `config` object from `react-spring`:
 
 ```js
 import { useSpring, animated, config } from 'react-spring/three'

--- a/docs/react-three-fiber/getting-started/your-first-scene.mdx
+++ b/docs/react-three-fiber/getting-started/your-first-scene.mdx
@@ -33,7 +33,7 @@ The Canvas component does some important setup work behind the scenes:
   just changing the `width` and `height` of `#canvas-container` in your css.
 </Hint>
 
-To actually _render_ something in our scene, we'll add a `mesh` component. In Fiber, every THREE.js object has an equivalent component:
+To actually _render_ something in our scene, we'll add a `mesh` component. In Fiber, every three.js object has an equivalent component:
 
 ```js
 const myMesh = new THREE.Mesh()
@@ -43,7 +43,7 @@ const myMesh = new THREE.Mesh()
 
 ## Adding a Mesh Component
 
-A [`Mesh`](https://threejs.org/docs/#api/en/objects/Mesh) is a basic object in THREE.js, and it's used to hold the polygons and the material that are needed to represent the object in 3D space.
+A [`Mesh`](https://threejs.org/docs/#api/en/objects/Mesh) is a basic object in three.js, and it's used to hold the polygons and the material that are needed to represent the object in 3D space.
 We'll create a new mesh using a **BoxGeometry** component for the geometry and a **MeshPhongMaterial** component for the material.
 
 To actually add these objects to our scene, we mount them inside the `<Canvas />` component.
@@ -51,7 +51,7 @@ To actually add these objects to our scene, we mount them inside the `<Canvas />
 <Hint>
   Note that we don't need to import anything, THREE objects will be treated as native JSX elements,
   just like you can just write &lt;div /&gt; or &lt;span /&gt; in regular React. The general rule is
-  that Fiber components are available under the camel-case version of their name in THREE.js.
+  that Fiber components are available under the camel-case version of their name in three.js.
 </Hint>
 
 ```jsx
@@ -71,7 +71,7 @@ export default function App() {
 }
 ```
 
-Let's pause for a moment to understand exactly what is happening here. The code we just wrote is the equivalent to this THREE.js code:
+Let's pause for a moment to understand exactly what is happening here. The code we just wrote is the equivalent to this three.js code:
 
 ```jsx
 const scene = new THREE.Scene()
@@ -128,7 +128,7 @@ Next, we will add some lights to our scene, by putting these components as child
 
 ### Props
 
-This introduces us to the last fundamental concept of Fiber, how React `props` work on THREE objects. When you set any prop on a Fiber component, it will set the property of the same name on the THREE.js object.
+This introduces us to the last fundamental concept of Fiber, how React `props` work on THREE objects. When you set any prop on a Fiber component, it will set the property of the same name on the three.js object.
 
 Let's focus on our `ambientLight`, whose [documentation](https://threejs.org/docs/#api/en/lights/AmbientLight) tells us that we can optionally construct it with a color, but can also receive props.
 


### PR DESCRIPTION
Hi all, thanks for the great library and the new docs. I particularly like the conversational style and ample demos.

I made a bunch of formatting fixes, fixed typos and improved a few sentences. Also I noticed that three.js was written a variety of ways (ThreeJS, Threejs, Three.js, threejs, three.js, Three.js), not a very big deal but it's nice if things are consistent so I changed all to 'three.js'. I went for this one because that's how it's written in the three.js docs.
Some goes for react-three/fiber which alternately written as 'Fiber', 'React Three Fiber', 'react-three-fiber', 'react three fiber'. Again, I think it's better if this is consistent throughout the docs. My vote goes to 'react-three/fiber' or React Three Fiber. I think 'Fiber' is too ambiguous and  'react-three-fiber' might cause confusion with the <v6 un-namespaced package.