### PR TITLE
Menu Icon visibility

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -48,7 +48,7 @@ export default function Layout({ nav, toc, children }) {
           </div>
         </Link>
         <Search />
-        <button className="block md:hidden p-2 mr-2 ml-2" onClick={toggleMenu}>
+        <button className="block lg:hidden p-2 mr-2 ml-2" onClick={toggleMenu}>
           <MenuIcon />
         </button>
       </div>


### PR DESCRIPTION
Menu Icon should be visible until 1024px screen width, otherwise there is no menu between 768 and 1023px screen width.