### PR TITLE
Prefix data libraries item in Link with /

### DIFF
--- a/components/LibSwitcher.tsx
+++ b/components/LibSwitcher.tsx
@@ -22,7 +22,7 @@ export default function LibSwitcher() {
       <Popover.Panel className="absolute z-10 w-full mt-4 p-3 shadow-xl bg-white rounded-md">
         <div className="flex flex-col space-y-3">
           {data.map((item) => (
-            <Link key={item.id} href={item.id}>
+            <Link key={item.id} href={`/${item.id}`}>
               <a
                 className={cx(
                   'px-3 py-2 hover:bg-gray-50 rounded-md font-normal',


### PR DESCRIPTION
currently, for example, if you want to go from  `jotai` docs to `zustand`, it redirects you to `/jotai/zustand` .
this PR fixes that.