### PR TITLE
Fix the broken link

### DIFF
--- a/docs/jotai/basics/primitives.mdx
+++ b/docs/jotai/basics/primitives.mdx
@@ -55,7 +55,7 @@ It's reactive and read dependencies are tracked.
 
 `get` in the write function is also to read atom value, and it's not tracked.
 Furthermore, it can't read unresolved async values.
-For async behavior, please refer to the [async](/jotai/async) doc.
+For async behavior, please refer to the [async](/jotai/basics/async) doc.
 
 `set` in the write function is to write atom value.
 It will invoke the write function of the target atom.


### PR DESCRIPTION
`/jotai/async` -> `/jotai/basics/async`