### PR TITLE
fix(docs): preload fonts to avoid initial flash

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,7 +7,7 @@
   src: url('/fonts/inter-var.woff2') format('woff2');
   font-weight: 100 900;
   font-style: normal;
-  font-display: block;
+  font-display: swap;
   font-named-instance: 'Regular';
 }
 
@@ -16,7 +16,7 @@
   src: url('/fonts/inter-italic-var.woff2') format('woff2');
   font-weight: 100 900;
   font-style: italic;
-  font-display: block;
+  font-display: swap;
   font-named-instance: 'Italic';
 }
 
@@ -25,7 +25,7 @@
   src: url('/fonts/meslo.woff2') format('woff2');
   font-weight: normal;
   font-style: normal;
-  font-display: block;
+  font-display: swap;
 }
 
 * {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -33,6 +33,10 @@ function App({ Component, pageProps }: AppProps) {
         <meta name="twitter:site" content="@pmndrs" />
         <meta property="og:locale" content="en_us" />
         <meta property="og:type" content="website" />
+
+        <link rel="preload" href="/fonts/inter-var.woff2" as="font" crossOrigin="" />
+        <link rel="preload" href="/fonts/inter-italic-var.woff2" as="font" crossOrigin="" />
+        <link rel="preload" href="/fonts/meslo.woff2" as="font" crossOrigin="" />
       </Head>
       <Component {...pageProps} />
     </>


### PR DESCRIPTION
From: #102.

This pull request preloads global fonts and changes their display behavior to maintain visibility.

Related:
 - https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
 - https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload