### PR TITLE
Fix `selectAtom` example

### DIFF
--- a/docs/jotai/api/utils.mdx
+++ b/docs/jotai/api/utils.mdx
@@ -436,8 +436,8 @@ const defaultPerson = {
     month: 'Jan',
     day: 1,
     time: {
-      hour: number,
-      minute: number,
+      hour: 1,
+      minute: 1,
     },
   },
 }


### PR DESCRIPTION
`birth.time.hour` and `minute` had type `number`, not valid values.