### PR TITLE
fix(docs): parse snippets in headings, fix associated links

### DIFF
--- a/remark/withTableofContents.ts
+++ b/remark/withTableofContents.ts
@@ -10,15 +10,23 @@ const withTableofContents = (toc?: any[]) => {
     for (let i = 0; i < tree.children.length; i++) {
       const node = tree.children[i]
       if (node.type === 'heading' && [2, 3].includes(node.depth)) {
-        const title = node.children
-          .filter((n) => n.type === 'text')
-          .map((n) => n.value)
-          .join('')
+        const children = node.children.filter((n) => ['text', 'inlineCode'].includes(n.type))
 
+        const title = children
+          .map((n) =>
+            n.type === 'inlineCode'
+              ? // Cleanup links for code-only titles
+                n.value.replace(/^(get|set)\s|\(.+|\??\:.+/, '')
+              : n.value
+          )
+          .join('')
         const slug = slugify(title)
 
+        const content = children
+          .map((n) => (n.type === 'text' ? n.value : `<${n.type}>{'${n.value}'}</${n.type}>`))
+          .join('')
         node.type = 'jsx'
-        node.value = `<Heading id={"${slug}"} level={${node.depth}}>${title}</Heading>`
+        node.value = `<Heading id={"${slug}"} level={${node.depth}}>${content}</Heading>`
 
         if (Array.isArray(toc)) {
           toc.push({ slug, title, depth: node.depth })

--- a/remark/withTableofContents.ts
+++ b/remark/withTableofContents.ts
@@ -16,7 +16,7 @@ const withTableofContents = (toc?: any[]) => {
           .map((n) =>
             n.type === 'inlineCode'
               ? // Cleanup links for code-only titles
-                n.value.replace(/^(get|set)\s|\(.+|\??\:.+/, '')
+                n.value.replace(/^(get|set)\s|\(.+|\??\:.+/g, '')
               : n.value
           )
           .join('')


### PR DESCRIPTION
Continues #93.

Headings do not display nor link right in production when they only contain inline code.

 - [x] parse code as headers
 - [x] preserve DOM structure in headers
 - [x] cleanup auto-generated links for code headers

An issue with the current implementation is that authors do not provide alternate text for some snippets. This means that we have to guess what to call each method/property. When listing different forms of arguments for some methods, subsequent will point to their parent (see [react-spring/classes/spring-value#start](https://website-git-fix-code-titles-pmndrs.vercel.app/react-spring/classes/spring-value#start)).