### PR TITLE
fix(docs): inform next about external images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  images: {
+    domains: ['codesandbox.io'],
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
Configures next to treat codesandbox thumbnails as external images.