### PR TITLE
Correct link to https://gltf.pmnd.rs/

### DIFF
--- a/docs/react-three-fiber/getting-started/loading-models.mdx
+++ b/docs/react-three-fiber/getting-started/loading-models.mdx
@@ -42,7 +42,7 @@ You can play with the sandbox and see how it looks here after I added an HDRI ba
 
 Here comes the really fancy part, you can transform these models into React components and then use them as your would any React component.
 
-To do this, grab your `GLTF` model and head over to [https://gltf.pmnd.rs/](gltf.pmnd.rs) and drop your `GLTF`, after that you should see something like:
+To do this, grab your `GLTF` model and head over to [https://gltf.pmnd.rs/](https://gltf.pmnd.rs/) and drop your `GLTF`, after that you should see something like:
 
 ![gltfjsx](./gltfjsx.png)
 


### PR DESCRIPTION
Currently this link points to `https://docs.pmnd.rs/react-three-fiber/getting-started/gltf.pmnd.rs`