### PR TITLE
Update atom-creators.mdx

### DIFF
--- a/docs/jotai/advanced-recipes/atom-creators.mdx
+++ b/docs/jotai/advanced-recipes/atom-creators.mdx
@@ -18,7 +18,7 @@ export function atomWithToggle(initialValue?: boolean): WritableAtom<boolean, bo
     set(anAtom, update)
   })
 
-  return anAtom
+  return anAtom as WritableAtom<boolean, boolean | undefined>
 }
 ```
 


### PR DESCRIPTION
Cast the return type. Otherwise the return atom has problems with the undefined read property.