### PR TITLE
Fix typo in Jotai's XState integration page

### DIFF
--- a/docs/jotai/integrations/xstate.mdx
+++ b/docs/jotai/integrations/xstate.mdx
@@ -6,7 +6,7 @@ nav: 4.4
 
 This doc describes `jotai/xstate` bundle.
 
-Jotai's state management is privimite and flexible,
+Jotai's state management is primitive and flexible,
 but that sometimes means too free.
 XState is a sophisticated library to provide
 a better and safer abstraction for state management.


### PR DESCRIPTION
Replaces "privimite" with "primitive".