### PR TITLE
Fixing missing zustand-bear logo on the zustand docs introduction page

### DIFF
--- a/docs/zustand/introduction.mdx
+++ b/docs/zustand/introduction.mdx
@@ -5,7 +5,7 @@ nav: 0
 ---
 
 <p align="center">
-  <img width="500" src="/zustand-bear.png" />
+  <img width="500" src="/zustand-resources/bear.png" />
 </p>
 A small, fast and scalable bearbones state-management solution. Has a comfy api based on hooks, isn't
 boilerplatey or opinionated, but still just enough to be explicit and flux-like.


### PR DESCRIPTION
This will fix #131

<img width="1792" alt="Screen Shot 2021-07-17 at 9 44 48 PM" src="https://user-images.githubusercontent.com/12088143/126054012-106635b4-4901-4ac9-b91b-d756f64cdbcb.png">
