### PR TITLE
Fix typo from "supsense" to "suspense"

### DIFF
--- a/docs/react-three-fiber/advanced/scaling-performance.mdx
+++ b/docs/react-three-fiber/advanced/scaling-performance.mdx
@@ -23,7 +23,7 @@ The following sandbox goes through three loading stages:
 
 <Codesandbox id="7duy8" />
 
-And this is how easy it is to achieve it, you can nest supsense and even use it as a fallback:
+And this is how easy it is to achieve it, you can nest suspense and even use it as a fallback:
 
 ```jsx
 function App() {


### PR DESCRIPTION
Small typo