### PR TITLE
fix(docs): add redirects for altered routes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,47 @@ module.exports = {
         destination: '/:slug*',
         permanent: true,
       },
+      // Redirects to prevent link breakage (https://github.com/pmndrs/website/issues/139)
+      {
+        source: '/react-three-fiber/examples/showcase',
+        destination: '/react-three-fiber/getting-started/examples',
+        permanent: true,
+      },
+      {
+        source: '/react-three-fiber/getting-started/basic-animations',
+        destination: '/react-three-fiber/tutorials/basic-animations',
+        permanent: true,
+      },
+      {
+        source: '/react-three-fiber/getting-started/events-and-interaction',
+        destination: '/react-three-fiber/tutorials/events-and-interaction',
+        permanent: true,
+      },
+      {
+        source: '/react-three-fiber/advanced/how-it-works',
+        destination: '/react-three-fiber/tutorials/how-it-works',
+        permanent: true,
+      },
+      {
+        source: '/react-three-fiber/getting-started/loading-models',
+        destination: '/react-three-fiber/tutorials/loading-models',
+        permanent: true,
+      },
+      {
+        source: '/react-three-fiber/getting-started/loading-textures',
+        destination: '/react-three-fiber/tutorials/loading-textures',
+        permanent: true,
+      },
+      {
+        source: '/react-three-fiber/getting-started/testing',
+        destination: '/react-three-fiber/tutorials/testing',
+        permanent: true,
+      },
+      {
+        source: '/react-three-fiber/getting-started/using-with-react-spring',
+        destination: '/react-three-fiber/tutorials/using-with-react-spring',
+        permanent: true,
+      },
     ]
   },
 }


### PR DESCRIPTION
Fixes #139 by adding redirects for moved docs from https://github.com/pmndrs/website/commit/d5b3960cf189046f30dabcb75a559272dff1ce54 and https://github.com/pmndrs/website/commit/0f03414a787b9728becf7c2ad17b08118f2f3066.