### PR TITLE
Jotai: add useHydrateAtoms docs

### DIFF
--- a/docs/jotai/api/utils.mdx
+++ b/docs/jotai/api/utils.mdx
@@ -734,3 +734,47 @@ const App = () => {
 ### Codesandbox
 
 <Codesandbox id="krwsv" />
+
+## useHydrateAtoms
+
+Ref: https://github.com/pmndrs/jotai/issues/340
+
+### Usage
+
+```tsx
+import { atom, useAtom } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+
+const countAtom = atom(0)
+const CounterPage = ({ countFromServer }) => {
+  useHydrateAtoms([[countAtom, countFromServer]])
+  const [count] = useAtom(countAtom)
+  // count would be the value of `countFromServer`, not 0.
+}
+```
+
+The primary use case for `useHydrateAtoms` are SSR apps like Next.js, where an initial value is e.g. fetched on the server, which can be passed to a component by props.
+
+```ts
+// Definition
+function useHydrateAtoms(values: Iterable<readonly [Atom<unknown>, unknown]>, scope?: Scope): void
+```
+
+The hook takes an iterable of tuples containing `[atom, value]` as an argument and optionally scope.
+
+```ts
+// Usage with an array, specifying a scope
+useHydrateAtoms([[countAtom, 42], [frameworkAtom, "Next.js"]], myScope)
+// Or with a map
+const [initialValues] = useState(() => new Map([[count, 42]]))
+useHydrateAtoms(initialValues)
+```
+
+Atoms can only be hydrated once per scope. Therefore, if the initial value used is changed during rerenders, it won't update the atom value.
+
+If there's a need to hydrate in multiple scopes, use multiple `useHydrateAtoms` hooks to achieve that.
+
+```ts
+useHydrateAtoms([[countAtom, 42], [frameworkAtom, "Next.js"]])
+useHydrateAtoms([[countAtom, 17], [frameworkAtom, "Gatsby"]], myScope)
+```

--- a/docs/jotai/api/utils.mdx
+++ b/docs/jotai/api/utils.mdx
@@ -778,3 +778,9 @@ If there's a need to hydrate in multiple scopes, use multiple `useHydrateAtoms` 
 useHydrateAtoms([[countAtom, 42], [frameworkAtom, "Next.js"]])
 useHydrateAtoms([[countAtom, 17], [frameworkAtom, "Gatsby"]], myScope)
 ```
+
+### Codesandbox
+
+<Codesandbox id="snu7n" />
+
+There's more examples in the [Next.js section](/jotai/guides/nextjs).

--- a/docs/jotai/guides/nextjs.mdx
+++ b/docs/jotai/guides/nextjs.mdx
@@ -8,6 +8,10 @@ Jotai has support for hydration of atoms with `useHydrateAtoms`. The documentati
 
 ## You can't return promises in server side rendering
 
+It's important to note that you can't return promises with SSR - However, it's possible to guard against it inside the atom definition.
+
+If possible use `useHydrateAtoms` to hydrate values from the server.
+
 ```js
 const postData = atom((get) => {
   const id = get(postId)
@@ -27,3 +31,14 @@ const postData = atom((get) => {
 ### HN Posts
 
 <Codesandbox id="819n4" />
+
+### Next.js repo
+
+```bash
+npx create-next-app --example with-jotai with-jotai-app
+# or
+yarn create next-app --example with-jotai with-jotai-app
+```
+
+Here's a [link](https://github.com/vercel/next.js/tree/canary/examples/with-jotai).
+

--- a/docs/jotai/guides/nextjs.mdx
+++ b/docs/jotai/guides/nextjs.mdx
@@ -18,3 +18,12 @@ const postData = atom((get) => {
 })
 ```
 
+## Examples
+
+### Clock
+
+<Codesandbox id="snu7n" />
+
+### HN Posts
+
+<Codesandbox id="819n4" />

--- a/docs/jotai/guides/nextjs.mdx
+++ b/docs/jotai/guides/nextjs.mdx
@@ -4,6 +4,8 @@ description: How to use Jotai with Next.js
 nav: 3.4
 ---
 
+Jotai has support for hydration of atoms with `useHydrateAtoms`. The documentation for the hook can be seen [here](/jotai/api/utils#use-hydrate-atoms).
+
 ## You can't return promises in server side rendering
 
 ```js
@@ -16,16 +18,3 @@ const postData = atom((get) => {
 })
 ```
 
-## Hydration is possible with care
-
-Check the following examples.
-
-## Examples
-
-### Clock
-
-<Codesandbox id="5ylrj" />
-
-### HN Posts
-
-<Codesandbox id="pm0l8" />

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
Add docs for useHydrateAtoms. It's missing an example, I'll try to add an example to the Next.js using Jotai.