### PR TITLE
fix: svg logo title not showing

### DIFF
--- a/docs/jotai/introduction.mdx
+++ b/docs/jotai/introduction.mdx
@@ -5,7 +5,7 @@ nav: 0
 ---
 
 <p align="center">
-  <img src="https://github.com/pmndrs/jotai/raw/master/img/title.svg" alt="jotai" />
+  <img src="https://github.com/pmndrs/jotai/raw/main/img/title.svg" alt="jotai" />
 </p>
 
 👻 Primitive and flexible state management for React.


### PR DESCRIPTION
I was reading `jotai` docs and noticed that the `Jotai` SVG isn't loading. So I tried fixing it. Please close this PR if you don't like these types of PR.

![image](https://user-images.githubusercontent.com/52126165/129063902-781ee07c-ba9b-4f55-a2d7-579c355625bb.png)
