### PR TITLE
docs(R3F): Fix incorrect wording

### DIFF
--- a/docs/react-three-fiber/advanced/pitfalls.mdx
+++ b/docs/react-three-fiber/advanced/pitfalls.mdx
@@ -90,9 +90,9 @@ useFrame(() => (ref.current.position.x = api.getState().x))
 return <mesh ref={ref} />
 ```
 
-### ✅ Or, subscribe transitently
+### ✅ Or, subscribe transiently
 
-See: [transiten updates for often occurring state changes](https://github.com/react-spring/zustand#transient-updates-for-often-occuring-state-changes).
+See: [transient updates for often occurring state changes](https://github.com/react-spring/zustand#transient-updates-for-often-occuring-state-changes).
 
 ```jsx
 const ref = useRef()


### PR DESCRIPTION
Rename the word `transitent` (typo) to `transient` in the R3F docs.