### PR TITLE
fix(docs): react-spring broken links

### DIFF
--- a/docs/react-spring/classes/spring-value.mdx
+++ b/docs/react-spring/classes/spring-value.mdx
@@ -91,7 +91,7 @@ the `queue` array has either finished or been cancelled.
 await spring.start()
 ```
 
-The awaited value is an [`AnimationResult`](/common/props#animation-result) object.
+The awaited value is an [`AnimationResult`](/react-spring/common/props#animation-result) object.
 
 ### `start(props): Promise`
 
@@ -108,7 +108,7 @@ await spring.start({ from: 0, to: 1 })
 
 Process the given array of updates.
 
-The returned promise resolves to an [`AnimationResult`](/common/props#animation-result) object whose:
+The returned promise resolves to an [`AnimationResult`](/react-spring/common/props#animation-result) object whose:
 
 - `finished` property is only `true` when every animation triggered by
   the `queue` was finished before being stopped or cancelled.

--- a/docs/react-spring/components/spring.mdx
+++ b/docs/react-spring/components/spring.mdx
@@ -49,7 +49,7 @@ The child of `Spring` is a render prop function.
 
 ## Properties
 
-All properties documented in the [common props](/common/props) apply.
+All properties documented in the [common props](/react-spring/common/props) apply.
 
 ## Additional notes
 

--- a/docs/react-spring/components/trail.mdx
+++ b/docs/react-spring/components/trail.mdx
@@ -23,7 +23,7 @@ If you re-render the component with changed props, the animation will update.
 
 ### Or: pass a function that returns values, and update using "set"
 
-You will get an API object back. It will not cause the component to render like an overwrite would (the animation still executes of course). Handling updates like this is useful for fast-occurring updates, and you should generally prefer it as it's more powerful. Further documentation can be found in [Imperatives & Refs](http://localhost:3000/common/imperatives-and-refs#api-methods)
+You will get an API object back. It will not cause the component to render like an overwrite would (the animation still executes of course). Handling updates like this is useful for fast-occurring updates, and you should generally prefer it as it's more powerful. Further documentation can be found in [Imperatives & Refs](/react-spring/common/imperatives-and-refs#api-methods)
 
 ```jsx
 const springRef = new SpringRef()
@@ -48,4 +48,4 @@ The return value is an array containing animated props.
 
 ## Properties
 
-All properties of the [shared-api](/docs/hooks/api) apply.
+All properties of the [shared-api](/react-spring/common/props) apply.

--- a/docs/react-spring/components/transition.mdx
+++ b/docs/react-spring/components/transition.mdx
@@ -46,7 +46,7 @@ const elems = transition((style, item, t, i) => <a.div style={style}>{t.phase}</
 
 ## Properties
 
-All properties of the [shared-api](/common/props) apply.
+All properties of the [shared-api](/react-spring/common/props) apply.
 
 | Property | Type              | Description                                                                                                                                                      |
 | -------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/react-spring/getting-started.mdx
+++ b/docs/react-spring/getting-started.mdx
@@ -11,7 +11,7 @@ nav: 1
 - `useTransition` for mount/unmount transitions (lists where items are added/removed/updated)
 - `useChain` to queue or chain multiple animations together -->
 
-The basic spring is [useSpring](/hooks/usespring), but the same concept applies to all animation primitives. Let's have a look...
+The basic spring is [useSpring](/react-spring/hooks/use-spring), but the same concept applies to all animation primitives. Let's have a look...
 
 ```jsx
 import { useSpring, animated } from 'react-spring'
@@ -36,7 +36,7 @@ You need the animation-primitive itself, and a special factory called `animated`
 const props = useSpring({ to: { opacity: 1 }, from: { opacity: 0 } })
 ```
 
-A spring simply animates values from one state to another. Updates are accumulative, springs remember all the values you ever pass. You can use arbitrary names. There are a couple of reserved keywords like "from" (for base values). [You can learn about the api here](/docs/hooks/api). The received props are not static values! These props are self-updating, you cannot use them in regular divs and such.
+A spring simply animates values from one state to another. Updates are accumulative, springs remember all the values you ever pass. You can use arbitrary names. There are a couple of reserved keywords like "from" (for base values). [You can learn about the api here](/react-spring/common/props). The received props are not static values! These props are self-updating, you cannot use them in regular divs and such.
 
 ### Finally, tie the animated values to your view
 
@@ -140,7 +140,7 @@ For now, they only exist in `@react-spring/web`. **Want them in native? Consider
 
 ## View interpolation
 
-In cases where you need to clamp or extrapolate, each animated value can interpolate inside the view, which is a powerful tool to have. The interpolate function called `to` either takes a function or an object which forms a range. Interpolations can also form chains which allows you to route one calculation into another or reuse them. [Look into the shared-api](/docs/hooks/api) for an object description.
+In cases where you need to clamp or extrapolate, each animated value can interpolate inside the view, which is a powerful tool to have. The interpolate function called `to` either takes a function or an object which forms a range. Interpolations can also form chains which allows you to route one calculation into another or reuse them. [Look into the shared-api](/react-spring/common/interpolation) for an object description.
 
 You may wonder why you wouldn't always interpolate inside of the spring. View interpolation can be a little faster, and it takes up less space.
 

--- a/docs/react-spring/hooks/use-spring.mdx
+++ b/docs/react-spring/hooks/use-spring.mdx
@@ -21,7 +21,7 @@ const styles = useSpring({ opacity: toggle ? 1 : 0 })
 
 ### Or: pass a function that returns values, and update using the api
 
-You will get an API object back. It will not cause the component to render like an overwrite would (the animation still executes of course). Handling updates like this is useful for fast-occurring updates, and you should generally prefer it as it's more powerful. Further documentation can be found in [Imperatives & Refs](http://localhost:3000/common/imperatives-and-refs#api-methods)
+You will get an API object back. It will not cause the component to render like an overwrite would (the animation still executes of course). Handling updates like this is useful for fast-occurring updates, and you should generally prefer it as it's more powerful. Further documentation can be found in [Imperatives & Refs](/react-spring/common/imperatives-and-refs#api-methods)
 
 ```jsx
 const [styles, api] = useSpring(() => ({ opacity: 1 }))
@@ -42,7 +42,7 @@ return <animated.div style={styles}>i will fade</animated.div>
 
 ## Properties
 
-All properties documented in the [common props](/common/props) apply.
+All properties documented in the [common props](/react-spring/common/props) apply.
 
 ## Additional notes
 

--- a/docs/react-spring/hooks/use-springs.mdx
+++ b/docs/react-spring/hooks/use-springs.mdx
@@ -45,7 +45,7 @@ return springs.map((styles) => <animated.div style={styles} />)
 
 ## Properties
 
-All properties documented in the [common props](/common/props) apply.
+All properties documented in the [common props](/react-spring/common/props) apply.
 
 ## Demos
 

--- a/docs/react-spring/hooks/use-trail.mdx
+++ b/docs/react-spring/hooks/use-trail.mdx
@@ -21,7 +21,7 @@ const trail = useTrail(amount, { opacity: 1 })
 
 ### Or: pass a function that returns values, and update using "set"
 
-You will get an API object back. It will not cause the component to render like an overwrite would (the animation still executes of course). Handling updates like this is useful for fast-occurring updates, and you should generally prefer it as it's more powerful. Further documentation can be found in [Imperatives & Refs](http://localhost:3000/common/imperatives-and-refs#api-methods)
+You will get an API object back. It will not cause the component to render like an overwrite would (the animation still executes of course). Handling updates like this is useful for fast-occurring updates, and you should generally prefer it as it's more powerful. Further documentation can be found in [Imperatives & Refs](/react-spring/common/imperatives-and-refs#api-methods)
 
 ```jsx
 const [trail, api] = useTrail(amount, () => ({ opacity: 1 }))
@@ -42,7 +42,7 @@ return trail.map((styles) => <animated.div style={styles} />)
 
 ## Properties
 
-All properties of the [shared-api](/docs/hooks/api) apply.
+All properties of the [shared-api](/react-spring/common/props) apply.
 
 ## Demos
 

--- a/docs/react-spring/hooks/use-transition.mdx
+++ b/docs/react-spring/hooks/use-transition.mdx
@@ -46,7 +46,7 @@ const elems = transition((style, item, t, i) => <a.div style={style}>{t.phase}</
 
 ## Properties
 
-All properties of the [shared-api](/common/props) apply.
+All properties of the [shared-api](/react-spring/common/props) apply.
 
 | Property | Type              | Description                                                                                                                                                      |
 | -------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
While reading the documentation for `react-spring` I noticed that a few of the internal links were broken. This PR tries to fix some of them (the ones I caught).

