### PR TITLE
fix(useLockBodyScroll): keep effect in client

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -11,7 +11,7 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { useSwitcher } from 'store/switcher'
 import { useMenu } from 'store/menu'
-import useLockBodyScroll from 'utils/useLockBodyScroll'
+import useLockBodyScroll from 'hooks/useLockBodyScroll'
 import { useDocs } from 'store/docs'
 
 export default function Layout({ nav, toc, children }) {

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,6 +1,6 @@
 import { animated as a, useTransition } from 'react-spring'
 import { switcherModalRef } from 'store/switcher'
-import useLockBodyScroll from 'utils/useLockBodyScroll'
+import useLockBodyScroll from 'hooks/useLockBodyScroll'
 
 type SimpleModalProps = {
   open: boolean

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import useSearch, { Result } from 'hooks/useSearch'
 import useKeyPress from 'hooks/useKeyPress'
-import useLockBodyScroll from 'utils/useLockBodyScroll'
+import useLockBodyScroll from 'hooks/useLockBodyScroll'
 import SearchModal from './SearchModal'
 import { useDocs } from 'store/docs'
 

--- a/hooks/useLockBodyScroll.ts
+++ b/hooks/useLockBodyScroll.ts
@@ -1,7 +1,10 @@
-import { useLayoutEffect } from 'react'
+import { useLayoutEffect, useEffect } from 'react'
+
+// Conditionally run on the client (useEffect is no-op server-side)
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 function useLockBodyScroll(active = false) {
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!active) return
     // Get original body overflow
     const originalStyle = window.getComputedStyle(document.body).overflow
@@ -11,7 +14,7 @@ function useLockBodyScroll(active = false) {
     return () => {
       document.body.style.overflow = originalStyle
     }
-  }, [active]) // Empty array ensures effect is only run on mount and unmount
+  }, [active])
 }
 
 export default useLockBodyScroll


### PR DESCRIPTION
Has the hook only apply to the client and gets rid of the scary react server warnings. Nothing in uppercase and no underscores, so we're probably fine.