### PR TITLE
Fix small typo

### DIFF
--- a/docs/jotai/advanced-recipes/large-objects.mdx
+++ b/docs/jotai/advanced-recipes/large-objects.mdx
@@ -98,7 +98,7 @@ Assume we want to consume the info data, and its data is always unchangeable, so
 const readOnlyInfoAtom = atom((get) => get(dataAtom).info)
 ```
 
-Then we can going to consume it in our component:
+Then we are going to consume it in our component:
 
 ```jsx
 import { atom, useAtom } from 'jotai'


### PR DESCRIPTION
Fix a small typo by replacing a single word.