### PR TITLE
chore: Bump up Next.js to latest v11.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "next": "10.0.5",
+    "next": "11.1.2",
     "next-pwa": "5.0.5",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "sass": "1.32.7"
   },
   "license": "MIT",
@@ -14,3 +14,4 @@
     "start": "next start"
   }
 }
+


### PR DESCRIPTION
Bump up Next.js to latest release: v11
