### PR TITLE
fix(docs): remove duplicate ToC links, generate labels

### DIFF
--- a/components/Toc.tsx
+++ b/components/Toc.tsx
@@ -4,6 +4,7 @@ type TocItem = {
   depth: number
   slug: string
   title: string
+  label: string
 }
 
 type Toc = TocItem[]
@@ -21,6 +22,7 @@ function Toc({ toc }: TocProps) {
       {toc.map((item) => (
         <h4 key={item.slug} className={clsx(item.depth === 3 && 'ml-4')}>
           <a
+            aria-label={item.label}
             className="block py-1 text-sm font-normal leading-6 text-gray-500 hover:underline"
             href={`#${item.slug}`}
           >

--- a/components/mdx/index.tsx
+++ b/components/mdx/index.tsx
@@ -44,7 +44,7 @@ const components = {
       </a>
     )
   },
-  Heading: ({ children, id, level }) => {
+  Heading: ({ children, id, level, ...rest }) => {
     const Comp = level === 2 ? 'h2' : 'h3'
     return (
       <a
@@ -54,6 +54,7 @@ const components = {
           level === 2 ? 'text-3xl mb-6 mt-8' : 'text-xl mb-4 mt-6',
           'tracking-tight'
         )}
+        {...rest}
       >
         <Comp id={id}>{children}</Comp>
       </a>

--- a/remark/withTableofContents.ts
+++ b/remark/withTableofContents.ts
@@ -30,7 +30,8 @@ const withTableofContents = (toc?: any[]) => {
         const isDuplicate = toc.find((previous) => previous.slug === slug)
         const isParent = node.depth === 2
 
-        const label = isParent ? slug : `${parents[parents.length - 1]} - ${slug}`
+        const parent = parents?.length && parents[parents.length - 1]
+        const label = isParent || !parent ? slug : `${parent} - ${slug}`
 
         // Remove duplicate heading links
         if (isDuplicate) {

--- a/remark/withTableofContents.ts
+++ b/remark/withTableofContents.ts
@@ -25,11 +25,16 @@ const withTableofContents = (toc?: any[]) => {
         const content = children
           .map((n) => (n.type === 'text' ? n.value : `<${n.type}>{'${n.value}'}</${n.type}>`))
           .join('')
-        node.type = 'jsx'
-        node.value = `<Heading id={"${slug}"} level={${node.depth}}>${content}</Heading>`
 
-        if (Array.isArray(toc)) {
-          toc.push({ slug, title, depth: node.depth })
+        node.type = 'jsx'
+
+        // Remove duplicate heading links
+        if (toc.find((previous) => previous.slug === slug)) {
+          node.value = `<Heading level={${node.depth}}>${content}</Heading>`
+        } else {
+          node.value = `<Heading id={"${slug}"} level={${node.depth}}>${content}</Heading>`
+
+          toc?.push?.({ slug, title, depth: node.depth })
         }
       }
     }


### PR DESCRIPTION
Updates the ToC to only include unique links and generates labels to address the accessibility issues outlined in #119.

Test links (`react-spring/classes/spring-value#start`):
  - [prod](https://docs.pmnd.rs/react-spring/classes/spring-value#start)
  - [PR](https://website-git-fix-dedup-toc-pmndrs.vercel.app/react-spring/classes/spring-value#start)