### PR TITLE
docs(Sandbox): render loading skeletons, lazy load sections

### DIFF
--- a/components/mdx/Sandbox.tsx
+++ b/components/mdx/Sandbox.tsx
@@ -37,7 +37,7 @@ export default function Sandbox({ id }) {
       {/* Render skeleton while loading */}
       {!data && (
         <>
-          <div aria-hidden className="loading rounded shadow-lg" style={{ height: 128 }} />
+          <div aria-hidden className="loading rounded" style={{ height: 128 }} />
           <h6 aria-hidden className="loading rounded text-gray-700 font-bold mt-4">
             loading
           </h6>

--- a/components/mdx/Sandbox.tsx
+++ b/components/mdx/Sandbox.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useRef, useState, useEffect } from 'react'
 import Image from 'next/image'
 
 export default function Sandbox({ id }) {
+  const sandboxRef = useRef()
   const [data, setData] = useState<{
     alias: string
     screenshot_url: string
@@ -11,39 +12,77 @@ export default function Sandbox({ id }) {
   }>()
 
   useEffect(() => {
-    fetch(`/api/get-sandbox?id=${id}`)
-      .then((rsp) => rsp.json())
-      .then(setData)
+    // Wait to load section until in view
+    const sectionObserver = new IntersectionObserver(([entry], observer) => {
+      if (entry.isIntersecting) {
+        // Once observed, don't observe again
+        observer.unobserve(entry.target)
+
+        // Fetch once observed
+        fetch(`/api/get-sandbox?id=${id}`)
+          .then((rsp) => rsp.json())
+          .then(setData)
+      }
+    })
+
+    sectionObserver.observe(sandboxRef.current)
+
+    return () => {
+      sectionObserver.disconnect()
+    }
   }, [id])
 
-  if (!data) return null
-
   return (
-    <div>
-      <a href={`https://codesandbox.io/s/${data.alias}`} target="_blank" rel="noreferrer">
-        <Image
-          className="rounded shadow-lg"
-          src={`https://codesandbox.io/api/v1/sandboxes/${id}/screenshot.png`}
-          alt={data.title}
-          width={1763}
-          height={926}
-          loading="lazy"
-        />
-      </a>
-      <h6 className="text-gray-700 font-bold mt-4">{data.title}</h6>
-      <p className="text-gray-700">{data.description}</p>
-      <div className="w-full">
-        {data.tags.map((tag, i) => (
-          <span
-            key={i}
-            className={`inline-block mt-1 text-gray-500 bg-gray-100 rounded px-1 py-1 text-xs ${
-              i !== data.tags.length - 1 ? 'mr-1' : null
-            }`}
-          >
-            {tag}
-          </span>
-        ))}
-      </div>
+    <div ref={sandboxRef}>
+      {/* Render skeleton while loading */}
+      {!data && (
+        <>
+          <div aria-hidden className="loading rounded shadow-lg" style={{ height: 128 }} />
+          <h6 aria-hidden className="loading rounded text-gray-700 font-bold mt-4">
+            loading
+          </h6>
+          <p aria-hidden className="loading rounded text-gray-700 mt-1">
+            loading
+          </p>
+          <div className="w-full">
+            <span
+              aria-hidden
+              className="loading inline-block mt-2 text-gray-500 bg-gray-100 rounded px-1 py-1 text-xs mr-1"
+            >
+              loading
+            </span>
+          </div>
+        </>
+      )}
+      {data && (
+        <>
+          <a href={`https://codesandbox.io/s/${data.alias}`} target="_blank" rel="noreferrer">
+            <Image
+              className="rounded shadow-lg"
+              src={`https://codesandbox.io/api/v1/sandboxes/${id}/screenshot.png`}
+              placeholder="empty"
+              alt={data.title}
+              width={1763}
+              height={926}
+              loading="lazy"
+            />
+          </a>
+          <h6 className="text-gray-700 font-bold mt-4">{data.title}</h6>
+          <p className="text-gray-700 mt-1">{data.description}</p>
+          <div className="w-full">
+            {data.tags.map((tag, i) => (
+              <span
+                key={i}
+                className={`inline-block mt-2 text-gray-500 bg-gray-100 rounded px-1 py-1 text-xs ${
+                  i !== data.tags.length - 1 ? 'mr-1' : ''
+                }`}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/css/main.css
+++ b/css/main.css
@@ -243,10 +243,10 @@ ul.grid-list > li:before {
 }
 
 .loading {
-  --fillColor: rgb(243, 244, 246);
-  --revealColor: rgb(255, 255, 255);
+  --fillColor: 243 244 246;
+  --revealColor: 255 255 255;
 
-  background: var(--fillColor);
+  background: rgb(var(--fillColor));
   color: transparent;
   position: relative;
 }
@@ -255,10 +255,10 @@ ul.grid-list > li:before {
   animation: loading 2s infinite;
   background-image: linear-gradient(
     90deg,
-    rgba(var(--revealColor), 0) 0,
-    rgba(var(--revealColor), 0.2) 20%,
-    rgba(var(--revealColor), 0.5) 60%,
-    rgba(var(--revealColor), 0)
+    rgb(var(--revealColor) / 0) 0,
+    rgb(var(--revealColor) / 0.2) 20%,
+    rgb(var(--revealColor) / 0.5) 60%,
+    rgb(var(--revealColor) / 0)
   );
   content: '';
   inset: 0;

--- a/css/main.css
+++ b/css/main.css
@@ -235,3 +235,33 @@ ul.grid-list > li:before {
     font-size: 0.4em !important;
   }
 }
+
+@keyframes loading {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.loading {
+  --fillColor: rgb(243, 244, 246);
+  --revealColor: rgb(255, 255, 255);
+
+  background: var(--fillColor);
+  color: transparent;
+  position: relative;
+}
+
+.loading::after {
+  animation: loading 2s infinite;
+  background-image: linear-gradient(
+    90deg,
+    rgba(var(--revealColor), 0) 0,
+    rgba(var(--revealColor), 0.2) 20%,
+    rgba(var(--revealColor), 0.5) 60%,
+    rgba(var(--revealColor), 0)
+  );
+  content: '';
+  inset: 0;
+  position: absolute;
+  transform: translateX(-100%);
+}


### PR DESCRIPTION
Fixes #187 by both rendering a skeleton for suspended sandboxes and waits to load them until they've entered view.

You can compare the layout shifts between [prod](https://docs.pmnd.rs/react-three-fiber/getting-started/examples#game-prototypes) and [this pr](https://website-git-fix-docs-sandbox-pmndrs.vercel.app/react-three-fiber/getting-started/examples#game-prototypes).