### PR TITLE
docs(drei): change useResource to useState

### DIFF
--- a/docs/drei/controls/introduction.mdx
+++ b/docs/drei/controls/introduction.mdx
@@ -8,12 +8,12 @@ If available, controls have damping enabled by default. They manage their own up
 Every control component can be used with a custom camera using the `camera` prop:
 
 ```jsx
-const myCamera = useResource()
+const [camera, set] = useState()
 
 return (
   <>
-    <PerspectiveCamera ref={myCamera} position={[0, 5, 5]} />
-    <OrbitControls camera={myCamera.current} />
+    <PerspectiveCamera ref={set} position={[0, 5, 5]} />
+    <OrbitControls camera={camera} />
   </>
 )
 ```


### PR DESCRIPTION
According to https://github.com/pmndrs/react-three-fiber/blob/master/markdown/changelog.md#removal-of-useresource, it seems we should use `useState` instead of `useResource`.