### PR TITLE
docs(fiber): add native installation instructions & example

### DIFF
--- a/docs/react-three-fiber/getting-started/installation.mdx
+++ b/docs/react-three-fiber/getting-started/installation.mdx
@@ -15,6 +15,7 @@ We've put together guides for getting started with each popular framework:
 
 - Create React App
 - Next.js
+- Expo
 <!-- - Gatsby -->
 
 If you just want to give it a try, fork this [example on codesandbox](https://codesandbox.io/s/rrppl0y8l4?file=/src/App.js)!
@@ -39,6 +40,32 @@ module.exports = withTM()
 ```
 
 Make sure to check out our [official next.js starter](https://github.com/pmndrs/react-three-next), too!
+
+## Expo & React Native
+
+This example uses `expo-cli` for the sake of simplicity, but you can use your own barebones setup if you wish.
+
+```bash
+# Install expo-cli, this will create our app
+npm install expo-cli -g
+
+# Create app and cd into it
+expo init my-app
+cd my-app
+
+# Install dependencies
+npm install three @react-three/fiber
+
+# Start
+expo start
+```
+
+Just import from native targets and that's it!
+
+```jsx
+import { Canvas } from '@react-three/fiber/native'
+import { useGLTF } from '@react-three/drei/native'
+```
 
 ## Without build tools
 

--- a/docs/react-three-fiber/getting-started/installation.mdx
+++ b/docs/react-three-fiber/getting-started/installation.mdx
@@ -54,7 +54,7 @@ expo init my-app
 cd my-app
 
 # Install dependencies
-npm install three @react-three/fiber
+npm install three @react-three/fiber@beta react@beta
 
 # Start
 expo start

--- a/docs/react-three-fiber/getting-started/introduction.mdx
+++ b/docs/react-three-fiber/getting-started/introduction.mdx
@@ -132,6 +132,8 @@ Live demo: https://codesandbox.io/s/icy-tree-brnsm?file=/src/App.tsx
 <details>
   <summary>Show React Native example</summary>
 
+This example uses `expo-cli` for the sake of simplicity, but you can use your own barebones setup if you wish.
+
 ```bash
 # Install expo-cli, this will create our app
 npm install expo-cli -g

--- a/docs/react-three-fiber/getting-started/introduction.mdx
+++ b/docs/react-three-fiber/getting-started/introduction.mdx
@@ -143,7 +143,7 @@ expo init my-app
 cd my-app
 
 # Install dependencies
-npm install three @react-three/fiber
+npm install three @react-three/fiber@beta react@beta
 
 # Start
 expo start

--- a/docs/react-three-fiber/getting-started/introduction.mdx
+++ b/docs/react-three-fiber/getting-started/introduction.mdx
@@ -129,6 +129,63 @@ Live demo: https://codesandbox.io/s/icy-tree-brnsm?file=/src/App.tsx
 
 </details>
 
+<details>
+  <summary>Show React Native example</summary>
+
+```bash
+# Install expo-cli, this will create our app
+npm install expo-cli -g
+
+# Create app and cd into it
+expo init my-app
+cd my-app
+
+# Install dependencies
+npm install three @react-three/fiber
+
+# Start
+expo start
+```
+
+```tsx
+import * as THREE from 'three'
+import React, { useRef, useState } from 'react'
+import { Canvas, useFrame } from '@react-three/fiber/native'
+
+function Box(props) {
+  const mesh = useRef(null)
+  const [hovered, setHover] = useState(false)
+  const [active, setActive] = useState(false)
+  useFrame((state, delta) => (mesh.current.rotation.x += 0.01))
+  return (
+    <mesh
+      {...props}
+      ref={mesh}
+      scale={active ? 1.5 : 1}
+      onClick={(event) => setActive(!active)}
+      onPointerOver={(event) => setHover(true)}
+      onPointerOut={(event) => setHover(false)}
+    >
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
+    </mesh>
+  )
+}
+
+export default function App() {
+  return (
+    <Canvas>
+      <ambientLight />
+      <pointLight position={[10, 10, 10]} />
+      <Box position={[-1.2, 0, 0]} />
+      <Box position={[1.2, 0, 0]} />
+    </Canvas>
+  )
+}
+```
+
+</details>
+
 ---
 
 ### Fundamentals


### PR DESCRIPTION
Adds installation and usage instructions for react-native to R3F docs for the upcoming beta release.