### PR TITLE
chore: cleanup SEO

### DIFF
--- a/components/LibSwitcher.tsx
+++ b/components/LibSwitcher.tsx
@@ -9,7 +9,7 @@ import { data } from '../data/libraries'
 export default function LibSwitcher() {
   const router = useRouter()
   const { query } = router
-  const currentPage = useMemo(() => data.find((item) => item.id === query.slug[0]).label, [query])
+  const currentPage = useMemo(() => data.find((item) => item.id === query.slug[0]).title, [query])
 
   return (
     <Popover className="relative mt-4">
@@ -26,7 +26,7 @@ export default function LibSwitcher() {
                   item.id === query.slug[0] && 'sr-only'
                 )}
               >
-                {item.label}
+                {item.title}
               </a>
             </Link>
           ))}

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -1,54 +1,14 @@
 import Head from 'next/head'
-
-const sites = {
-  'react-spring': {
-    title: 'React Spring',
-    image: 'https://docs.pmnd.rs/react-spring/share.jpg',
-    description: 'Bring your components to life with simple spring animation primitives for React',
-  },
-  'react-three-fiber': {
-    title: 'React Three Fiber',
-    image: 'https://docs.pmnd.rs/react-three-fiber/share.jpg',
-    description: 'React-three-fiber is a React renderer for three.js.',
-  },
-  drei: {
-    title: 'Drei',
-    image: 'https://docs.pmnd.rs/logo-drei.jpg',
-    description:
-      'Drei is a growing collection of useful helpers and abstractions for react-three-fiber.',
-  },
-
-  'react-postprocessing': {
-    title: 'React Postprocessing',
-    image: 'https://docs.pmnd.rs/react-processing.jpg',
-    description: 'React Postprocessing is a postprocessing wrapper for @react-three/fiber',
-  },
-  zustand: {
-    title: 'Zustand',
-    description:
-      'Zustand is a small, fast and scalable bearbones state-management solution, it has a comfy api based on hooks',
-    image: 'https://docs.pmnd.rs/zustand-resources/zustand-bear.jpg',
-  },
-  jotai: {
-    title: 'Jotai',
-    description: 'Jotai is a primitive and flexible state management library for React. 👻',
-    // image: 'https://docs.pmnd.rs/jotai-ghost.png',
-  },
-  a11y: {
-    title: 'React-three-a11y',
-    description:
-      '@react-three/a11y brings accessibility to webGL with easy-to-use react-three-fiber components',
-    image: 'https://docs.pmnd.rs/a11y/react-three-a11y-header.jpg',
-  },
-}
+import { data } from 'data/libraries'
 
 export default function SEO({ name }: { name: string }) {
-  const currentSeo = sites[name]
+  const currentSeo = data.find(({ id }) => id === name)
+  if (!currentSeo) return null
 
-  return currentSeo ? (
+  return (
     <Head>
       <title> {currentSeo.title} Documentation</title>
-      <meta property="og:site_name" content={`${currentSeo.title} documentation`} />
+      <meta property="og:site_name" content={`${currentSeo.title} Documentation`} />
       <meta name="description" content={currentSeo.description} />
 
       <meta property="og:type" content="website" />
@@ -63,5 +23,5 @@ export default function SEO({ name }: { name: string }) {
       <meta property="twitter:description" content={currentSeo.description} />
       <meta property="twitter:image" content={currentSeo.image} />
     </Head>
-  ) : null
+  )
 }

--- a/data/libraries.js
+++ b/data/libraries.js
@@ -1,52 +1,59 @@
-import zustandImage from './zustand-bear-small.png'
-import jotaiImage from './jotai-ghost-small.png'
+import zustandIcon from './zustand-bear-small.png'
+import jotaiIcon from './jotai-ghost-small.png'
 
 export const data = [
   {
     id: 'react-three-fiber',
-    label: 'React Three Fiber',
+    title: 'React Three Fiber',
     github: 'https://github.com/pmndrs/react-three-fiber',
     description: 'React-three-fiber is a React renderer for three.js',
+    image: 'https://docs.pmnd.rs/react-three-fiber/share.jpg',
   },
   {
     id: 'react-spring',
-    label: 'React Spring',
+    title: 'React Spring',
     github: 'https://github.com/pmndrs/react-spring',
     description: 'Bring your components to life with simple spring animation primitives for React',
+    image: 'https://docs.pmnd.rs/react-spring/share.jpg',
   },
   {
     id: 'drei',
-    label: 'Drei',
+    title: 'Drei',
     github: 'https://github.com/pmndrs/drei',
     description:
       'Drei is a growing collection of useful helpers and abstractions for react-three-fiber',
+    image: 'https://docs.pmnd.rs/logo-drei.jpg',
   },
   {
     id: 'zustand',
-    label: 'Zustand',
+    title: 'Zustand',
     github: 'https://github.com/pmndrs/zustand',
     description:
       'Zustand is a small, fast and scalable bearbones state-management solution, it has a comfy api based on hooks',
-    image: zustandImage,
+    icon: zustandIcon,
+    image: 'https://docs.pmnd.rs/zustand-resources/zustand-bear.jpg',
   },
   {
     id: 'jotai',
-    label: 'Jotai',
+    title: 'Jotai',
     github: 'https://github.com/pmndrs/jotai',
     description: 'Jotai is a primitive and flexible state management library for React',
-    image: jotaiImage,
+    icon: jotaiIcon,
+    // image: 'https://docs.pmnd.rs/jotai-ghost.png',
   },
   {
     id: 'a11y',
-    label: 'A11y',
+    title: 'A11y',
     github: 'https://github.com/pmndrs/react-three-a11y',
     description:
       '@react-three/a11y brings accessibility to webGL with easy-to-use react-three-fiber components',
+    image: 'https://docs.pmnd.rs/a11y/react-three-a11y-header.jpg',
   },
   {
     id: 'react-postprocessing',
-    label: 'React Postprocessing',
+    title: 'React Postprocessing',
     github: 'https://github.com/pmndrs/react-postprocessing',
     description: 'React Postprocessing is a postprocessing wrapper for @react-three/fiber',
+    image: 'https://docs.pmnd.rs/react-processing.jpg',
   },
 ]

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -2,8 +2,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Image from 'next/image'
-
-import { data } from '../data/libraries'
+import { data } from 'data/libraries'
 
 export default function HomePage() {
   return (
@@ -27,19 +26,19 @@ export default function HomePage() {
               <div className="relative z-10 flex flex-col justify-between h-full">
                 <div className="flex justify-between items-center px-6">
                   <div className="max-w-md">
-                    <div className="pt-4 font-bold text-lg">{item.label}</div>
+                    <div className="pt-4 font-bold text-lg">{item.title}</div>
                     <div className="flex-grow pr-4 pt-1 pb-4 text-base text-gray-500 !leading-relaxed">
                       {item.description}
                     </div>
                   </div>
-                  {item?.image && (
+                  {item?.icon && (
                     <div className="relative flex-shrink-0 w-20 h-20">
                       <a href={item.github} target="_blank" rel="noopener" className="block">
                         <Image
-                          src={item.image}
+                          src={item.icon}
                           layout="fill"
                           className="object-contain"
-                          alt={item.label}
+                          alt={item.title}
                           aria-hidden
                         />
                       </a>


### PR DESCRIPTION
Removes hardcoded SEO for libraries and pulls from `data/libraries`. This was made to unify configuration in #204, but I'm backporting this to tidy things up.