### PR TITLE
Fix wrong import in documentation

### DIFF
--- a/docs/react-three-fiber/tutorials/how-it-works.mdx
+++ b/docs/react-three-fiber/tutorials/how-it-works.mdx
@@ -180,7 +180,7 @@ Fiber also handles camera switching, meaning that the raycaster will always use 
 When using the `raycast` prop, the object will instead be picked using a custom ray:
 
 ```jsx
-import { useCamera } from '@react-three/fiber'
+import { useCamera } from '@react-three/drei'
 
 return <mesh raycast={useCamera(anotherCamera)} />
 ```


### PR DESCRIPTION
The import mentioned in https://docs.pmnd.rs/react-three-fiber/tutorials/how-it-works seems to be wrong. 

I believe `useCamera` was exported from `@react-three/fiber` initially but moved to `@react-three/drei` later on and this was not updated on the docs. Updated that in this PR. 