### PR TITLE
chore(mdx): remove duplicate InlineCode & cleanup R3F transclusion

### DIFF
--- a/components/mdx/index.tsx
+++ b/components/mdx/index.tsx
@@ -8,14 +8,6 @@ import { GridUsedBy } from './GridUsedBy'
 import { Demo } from './Demo'
 import { DemoGrid } from './DemoGrid'
 
-const InlineCode = ({ children }) => {
-  return (
-    <code className="px-2 py-1 rounded font-mono text-sm text-gray-800 bg-gray-100">
-      {children}
-    </code>
-  )
-}
-
 const components = {
   StoryBook,
   Demo,
@@ -57,6 +49,7 @@ const components = {
 
     const clampedLevel = Math.min(Math.max(level, 2), 4)
     const Comp = `h${clampedLevel}`
+
     return (
       <a
         href={`#${id}`}
@@ -71,34 +64,36 @@ const components = {
   ul: ({ children }) => <ul className="px-4 mb-8">{children}</ul>,
   ol: ({ children }) => <ol className="px-4 mb-8">{children}</ol>,
   li: ({ children }) => <li className="mb-4 text-base leading-6 text-gray-700">{children}</li>,
-  inlineCode: InlineCode,
-  InlineCode,
+  inlineCode: ({ children }) => (
+    <code className="px-2 py-1 rounded font-mono text-sm text-gray-800 bg-gray-100">
+      {children}
+    </code>
+  ),
   p: ({ children }) => <p className="mb-4 text-base text-gray-700">{children}</p>,
   blockquote: ({ children }) => (
     <blockquote className="mb-8 text-base pl-4 border-l-4 border-gray-600">{children}</blockquote>
   ),
-  table: ({ children }) => {
-    return (
-      <div className="flex flex-col my-6">
-        <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div className="py-6 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-            <div className="shadow-lg overflow-hidden border-b border-gray-200 sm:rounded-lg">
-              <table className="divide-y divide-gray-200 w-full"> {children}</table>
-            </div>
+  table: ({ children }) => (
+    <div className="flex flex-col my-6">
+      <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+        <div className="py-6 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+          <div className="shadow-lg overflow-hidden border-b border-gray-200 sm:rounded-lg">
+            <table className="divide-y divide-gray-200 w-full"> {children}</table>
           </div>
         </div>
       </div>
-    )
-  },
-  a: (props) => {
-    if (props.href.startsWith('https://')) {
+    </div>
+  ),
+  a: ({ href, children }) => {
+    if (href.startsWith('https://')) {
       return (
-        <a href={props.href} target="_blank" rel="noopener noreferrer">
-          {props.children}
+        <a href={href} target="_blank" rel="noopener noreferrer">
+          {children}
         </a>
       )
     }
-    return <a href={props.href}>{props.children}</a>
+
+    return <a href={href}>{children}</a>
   },
 }
 

--- a/docs/react-three-fiber/API/events.mdx
+++ b/docs/react-three-fiber/API/events.mdx
@@ -48,15 +48,18 @@ Also notice the `onPointerMissed` on the canvas element, which fires on clicks t
 ### How the event-system works, bubbling and capture
 
 <Hint>
-  the <InlineCode>pointerenter</InlineCode> and <InlineCode>pointerleave</InlineCode> events work
-  exactly the same as pointerover and pointerout. The
-  <InlineCode>pointerenter</InlineCode> and <InlineCode>pointerleave</InlineCode> semantics are not implemented.
+
+`pointerenter` and `pointerleave` events work exactly the same as pointerover and pointerout.
+`pointerenter` and `pointerleave` semantics are not implemented.
+
 </Hint>
 
 <Hint>
-  Some events (such as pointerout) happen when there is no intersection between
-  <InlineCode>eventObject</InlineCode> and the ray. When this happens, the event will contain intersection
-  data from a previous event with this object.
+
+Some events (such as `pointerout`) happen when there is no intersection between `eventObject` and
+the ray. When this happens, the event will contain intersection data from a previous event with
+this object.
+
 </Hint>
 
 ### Event propagation (bubbling)

--- a/docs/react-three-fiber/advanced/scaling-performance.mdx
+++ b/docs/react-three-fiber/advanced/scaling-performance.mdx
@@ -49,9 +49,11 @@ invalidate()
 ```
 
 <Hint>
-  Calling <InlineCode>invalidate()</InlineCode> will not render immediately, it merely requests a
-  new frame to be rendered out. Calling invalidate multiple times will not render multiple times.
-  Think of it as a flag to tell the system that something has changed.
+
+Calling `invalidate()` will not render immediately, it merely requests a
+new frame to be rendered out. Calling invalidate multiple times will not render multiple times.
+Think of it as a flag to tell the system that something has changed.
+
 </Hint>
 
 ## Re-using geometries and materials


### PR DESCRIPTION
This is a non-issue for MDX v2 or mdx-bundler, but this ensures that we can use any compiler without duplication.