### PR TITLE
Update scroll-controls.mdx

### DIFF
--- a/docs/drei/controls/scroll-controls.mdx
+++ b/docs/drei/controls/scroll-controls.mdx
@@ -8,7 +8,7 @@ Scroll controls create a HTML scroll container in front of the canvas. Everythin
 You can listen and react to scroll with the `useScroll` hook which gives you useful data like the current scroll `offset`, `delta` and functions for range finding: `range`, `curve` and `visible`. The latter functions are especially useful if you want to react to the scroll offset, for instance if you wanted to fade things in and out if they are in or out of view.
 
 ```jsx
-import { ScrollControls } from '@react-three/drei'
+import { ScrollControls, Scroll } from '@react-three/drei'
 
 <ScrollControls
   pages={3} // Each page takes 100% of the height of the canvas


### PR DESCRIPTION
I believe the example here was missing this import. Otherwise I get 
```Cannot find name 'Scroll'. Did you mean 'scroll'?ts(2552)```