### PR TITLE
docs(Drei): prototyping => staging

### DIFF
--- a/docs/drei/staging/stage.mdx
+++ b/docs/drei/staging/stage.mdx
@@ -21,4 +21,4 @@ Creates a "stage" with proper studio lighting, content centered and planar, shad
 
 <!--
 
-<StoryBook lib="drei"id="prototyping-usenormaltexture" /> -->
+<StoryBook lib="drei"id="staging-usenormaltexture" /> -->

--- a/docs/drei/staging/use-matcap-texture.mdx
+++ b/docs/drei/staging/use-matcap-texture.mdx
@@ -26,4 +26,4 @@ return (
 const [matcap] = useMatcapTexture('3E2335_D36A1B_8E4A2E_2842A5')
 ```
 
-<StoryBook lib="drei" id="prototyping-usematcaptexture" />
+<StoryBook lib="drei" id="staging-usematcaptexture" />

--- a/docs/drei/staging/use-normal-texture.mdx
+++ b/docs/drei/staging/use-normal-texture.mdx
@@ -24,4 +24,4 @@ return (
 
 ```
 
-<StoryBook lib="drei" id="prototyping-usenormaltexture" />
+<StoryBook lib="drei" id="staging-usenormaltexture" />


### PR DESCRIPTION
Fixes #228 by updating Drei's prototyping section to reference the new staging stories.