### PR TITLE
chore: fix invalid MDX syntax

### DIFF
--- a/docs/a11y/advanced/gotchas.mdx
+++ b/docs/a11y/advanced/gotchas.mdx
@@ -6,7 +6,7 @@ nav: 8
 
 ### Position of the accessible dom causing wrong hover detection
 
-In the demo, you may have noticed in App.js that the component ToggleButton is wrapped in an A11y component that use the prop a11yElStyle like so
+In the demo, you may have noticed in App.js that the component ToggleButton is wrapped in an A11y component that use the prop `a11yElStyle` like so
 
 ```jsx
 <A11y
@@ -31,7 +31,7 @@ If we inspect the DOM, you should see something roughly like this for the above 
 <button aria-pressed="false">Light intensity</button>
 ```
 
-By default this button is positionned in the center of your 3D object which would cause it to work like this.
+By default this button is positioned in the center of your 3D object which would cause it to work like this.
 
 1- Mouse is not over
 
@@ -57,7 +57,7 @@ If we display the button we can see that it's caused by the button being positio
   <img alt="" height="200" src="/a11y/hoverdefaultbecause.png" />
 </p>
 
-4- If we add a11yElStyle={{ marginLeft: '-40px' }} to the A11y component, the button is moved to the left and not in the center of the donut anymore
+4- If we add `a11yElStyle={{ marginLeft: '-40px' }}` to the A11y component, the button is moved to the left and not in the center of the donut anymore
 
 <p align="middle">
   <img alt="" height="200" src="/a11y/hoverfixbecause.png" />

--- a/docs/react-postprocessing/effects/ssao.mdx
+++ b/docs/react-postprocessing/effects/ssao.mdx
@@ -73,7 +73,7 @@ return (
         A texture that contains downsampled scene normals and depth. See
         <a href="https://vanruesc.github.io/postprocessing/public/docs/class/src/passes/DepthDownsamplingPass.js~DepthDownsamplingPass.html">
           DepthDownsamplingPass
-        </a>.
+        </a>
       </td>
     </tr>
     <tr>

--- a/docs/react-spring/changelog.mdx
+++ b/docs/react-spring/changelog.mdx
@@ -397,8 +397,8 @@ Nothing, except the removal of `/dist/`, and the experimental useSpring export m
 
 ### Configs
 
-- ⏰ Duration is built in and as easy as going `{`config={{ duration: 1000, easing: ... }}`}`
-- ⌛️ Delays can be driven per config `{`config={{ delay: 1000, ... }}`}`
+- ⏰ Duration is built in and as easy as going `config={{ duration: 1000, easing: ... }}`
+- ⌛️ Delays can be driven per config `config={{ delay: 1000, ... }}`
 - ✨ Simpler property names (mass, tension, friction, delay, precision, clamp, velocity, duration, easing)
 - 🎩 Spring config props are 1:1 compatible with react-motions and the presets finally do what they say
 
@@ -424,7 +424,7 @@ Nothing, except the removal of `/dist/`, and the experimental useSpring export m
 
 ### Keyframes
 
-- ✨ Simpler api. You don't have to write `{`to: {...}`}` any longer since everything is interpolated to it
+- ✨ Simpler api. You don't have to write `to: { ... }` any longer since everything is interpolated to it
 
 ### Parallax
 

--- a/docs/react-spring/common/configs.mdx
+++ b/docs/react-spring/common/configs.mdx
@@ -54,13 +54,13 @@ import { ..., config } from 'react-spring'
 useSpring({ ..., config: config.default })
 ```
 
-| Property        | Value                                    |
-| --------------- | ---------------------------------------- |
-| config.default  | { mass: 1, tension: 170, friction: 26 }  |
-| config.gentle   | { mass: 1, tension: 120, friction: 14 }  |
-| config.wobbly   | { mass: 1, tension: 180, friction: 12 }  |
-| config.stiff    | { mass: 1, tension: 210, friction: 20 }  |
-| config.slow     | { mass: 1, tension: 280, friction: 60 }  |
-| config.molasses | { mass: 1, tension: 280, friction: 120 } |
+| Property        | Value                                      |
+| --------------- | ------------------------------------------ |
+| config.default  | `{ mass: 1, tension: 170, friction: 26 }`  |
+| config.gentle   | `{ mass: 1, tension: 120, friction: 14 }`  |
+| config.wobbly   | `{ mass: 1, tension: 180, friction: 12 }`  |
+| config.stiff    | `{ mass: 1, tension: 210, friction: 20 }`  |
+| config.slow     | `{ mass: 1, tension: 280, friction: 60 }`  |
+| config.molasses | `{ mass: 1, tension: 280, friction: 120 }` |
 
 <Codesandbox id="kdv7r" />


### PR DESCRIPTION
Fixes some of the syntax errors that popped up during the parser upgrade (MDX 1 => MDX 2) in #232.

![image](https://user-images.githubusercontent.com/23324155/154870486-a9aa5006-71b1-4ebe-9557-d205e67f9932.png)