### PR TITLE
feat: improve search relevance

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -11,15 +11,14 @@ import { useRouter } from 'next/router'
 import { useSwitcher } from 'hooks/useSwitcher'
 import { useMenu } from 'hooks/useMenu'
 import { useLockBodyScroll } from 'hooks/useLockBodyScroll'
-import { useDocs } from 'hooks/useDocs'
-import { TocItem } from 'utils/rehype'
+import { Doc, useDocs } from 'hooks/useDocs'
 
 export interface LayoutProps {
-  toc: TocItem[]
+  doc: Doc
   children: React.ReactNode
 }
 
-export default function Layout({ toc, children }: LayoutProps) {
+export default function Layout({ doc, children }: LayoutProps) {
   const { isMenuOpen, toggleMenu, closeMenu } = useMenu()
   const { docs, getPrevAndNext } = useDocs()
 
@@ -143,7 +142,7 @@ export default function Layout({ toc, children }: LayoutProps) {
               </div>
 
               <div className="flex-none hidden w-64 pl-8 pr-8 xl:text-sm xl:block">
-                {toc.length ? <Toc toc={toc} /> : null}
+                {doc.tableOfContents.length ? <Toc toc={doc.tableOfContents} /> : null}
               </div>
             </div>
           </div>

--- a/components/Search/SearchItem.tsx
+++ b/components/Search/SearchItem.tsx
@@ -2,25 +2,29 @@ import Link from 'next/link'
 import Icon from 'components/Icon'
 import { highlight } from 'utils/text'
 
-export interface SearchItemProps {
-  url: string
-  search: string
+export interface SearchResult {
   title: string
-  description: string
+  description: string | null
+  url: string
 }
 
-function SearchItem({ url, search, title, description }: SearchItemProps) {
+export interface SearchItemProps {
+  search: string
+  result: SearchResult
+}
+
+function SearchItem({ search, result }: SearchItemProps) {
   return (
-    <Link href={url}>
+    <Link href={result.url}>
       <a className="block no-underline search-item outline-none">
         <li className="px-2 py-1">
           <div className="p-4 py-5 rounded-md bg-gray-100 hover:bg-gray-800 hover:text-gray-200 flex justify-between items-center transition-all">
             <span
               dangerouslySetInnerHTML={{
                 __html: `
-                ${highlight(title, search)}
+                ${highlight(result.title, search)}
                 <span class="block text-sm text-gray-600 pt-2">
-                  ${highlight(description, search)}
+                  ${highlight(result.description, search)}
                 </span>
               `,
               }}

--- a/components/Search/SearchModal.tsx
+++ b/components/Search/SearchModal.tsx
@@ -46,7 +46,7 @@ function SearchModal({ search, results, onClose, onChange }: SearchModelProps) {
           {renderList && (
             <ul className="list-none p-0 m-0 absolute left-0 bg-white pb-1 z-2 w-full rounded-b-md">
               {results.map((result, index) => (
-                <SearchItem key={`search-item-${index}`} search={search} {...result} />
+                <SearchItem key={`search-item-${index}`} search={search} result={result} />
               ))}
             </ul>
           )}

--- a/components/Toc.tsx
+++ b/components/Toc.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import clsx from 'clsx'
-import type { TocItem } from 'utils/rehype'
+import type { DocToC } from 'hooks/useDocs'
 
 export interface ToCProps {
-  toc: TocItem[]
+  toc: DocToC[]
 }
 
 function Toc({ toc }: ToCProps) {

--- a/hooks/useDocs.ts
+++ b/hooks/useDocs.ts
@@ -1,5 +1,14 @@
 import create from 'zustand'
 
+export interface DocToC {
+  id: string
+  level: number
+  title: string
+  description: string
+  url: string
+  parent?: DocToC
+}
+
 export interface Doc {
   slug: string[]
   url: string
@@ -8,6 +17,7 @@ export interface Doc {
   title: string
   description: string
   content: string
+  tableOfContents: DocToC[]
 }
 
 export interface DocState {

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -10,25 +10,25 @@ import SEO from 'components/Seo'
 import Post from 'components/Post'
 import { Doc, useDocs } from 'hooks/useDocs'
 import { CSB, CSBContext, fetchCSB } from 'hooks/useCSB'
-import { tableOfContents, codesandbox, TocItem } from 'utils/rehype'
+import { headings, codesandbox } from 'utils/rehype'
 import { getDocs } from 'utils/docs'
 
 export interface PostPageProps {
   docs: Doc[]
-  toc: TocItem[]
+  doc: Doc
   boxes: Record<string, CSB>
   title: string
   description?: string
   source: MDXRemoteSerializeResult
 }
 
-export default function PostPage({ docs, toc, boxes, title, description, source }: PostPageProps) {
+export default function PostPage({ docs, doc, boxes, title, description, source }: PostPageProps) {
   const { setDocs } = useDocs()
 
   React.useEffect(() => void setDocs(docs), [setDocs, docs])
 
   return (
-    <Layout toc={toc}>
+    <Layout doc={doc}>
       <SEO />
       <main className="max-w-3xl mx-auto">
         <div className="pb-6 mb-4 border-b post-header">
@@ -66,18 +66,17 @@ export const getStaticProps: GetStaticProps<PostPageProps> = async ({ params }) 
 
   const { title, description, content } = doc
 
-  const toc = []
   const ids = []
   const source = await serialize(content, {
     mdxOptions: {
       remarkPlugins: [gfm],
-      rehypePlugins: [prism, tableOfContents(toc), codesandbox(ids)],
+      rehypePlugins: [prism, headings, codesandbox(ids)],
     },
   })
 
   const boxes = await fetchCSB(ids)
 
-  return { props: { docs, toc, boxes, title, description, source }, revalidate: 300 }
+  return { props: { docs, doc, boxes, title, description, source }, revalidate: 300 }
 }
 
 export const getStaticPaths = async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "esnext",
+    "lib": ["dom", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,

--- a/utils/docs.ts
+++ b/utils/docs.ts
@@ -4,7 +4,7 @@ import http from 'isomorphic-git/http/node'
 import matter from 'gray-matter'
 import libs from 'data/libraries'
 import type { Doc, DocToC } from 'hooks/useDocs'
-import { sanitize } from './text'
+import { sanitize, slugify } from './text'
 
 /**
  * Checks for .md(x) file extension
@@ -102,7 +102,7 @@ export async function getDocs(lib?: keyof typeof libs): Promise<Doc[]> {
         const [prefix, ...rest] = heading.trim().split(' ')
         const level = prefix.length
         const title = sanitize(rest.join(' '))
-        const id = title.toLowerCase().replace(/\s+|-+/g, '-')
+        const id = slugify(title)
 
         const description = sanitize(
           content

--- a/utils/docs.ts
+++ b/utils/docs.ts
@@ -3,7 +3,8 @@ import git from 'isomorphic-git'
 import http from 'isomorphic-git/http/node'
 import matter from 'gray-matter'
 import libs from 'data/libraries'
-import type { Doc } from 'hooks/useDocs'
+import type { Doc, DocToC } from 'hooks/useDocs'
+import { sanitize } from './text'
 
 /**
  * Checks for .md(x) file extension
@@ -80,8 +81,8 @@ export async function getDocs(lib?: keyof typeof libs): Promise<Doc[]> {
 
       // Add fallback frontmatter
       const pathname = slug[slug.length - 1]
-      const title = compiled.data.title ?? pathname.replace(/\-/g, ' ')
-      const description = compiled.data.description ?? ''
+      const title = sanitize(compiled.data.title ?? pathname.replace(/\-/g, ' '))
+      const description = sanitize(compiled.data.description ?? '')
       const nav = compiled.data.nav ?? Infinity
 
       // Sanitize markdown
@@ -91,9 +92,41 @@ export async function getDocs(lib?: keyof typeof libs): Promise<Doc[]> {
         // Remove extraneous comments from post
         .replace(COMMENT_REGEX, '')
 
-      return { slug, url, editURL, title, description, nav, content }
+      const headings = content.matchAll(/^#{1,4}\s[^\n]+/gm)
+      const previous: Record<number, DocToC> = {}
+
+      const tableOfContents: DocToC[] = []
+
+      for (const match of headings) {
+        const [heading] = match
+        const [prefix, ...rest] = heading.trim().split(' ')
+        const level = prefix.length
+        const title = sanitize(rest.join(' '))
+        const id = title.toLowerCase().replace(/\s+|-+/g, '-')
+
+        const description = sanitize(
+          content
+            .substring(match.index)
+            .match(/^(\n|\s)*^\w[^\n]+/m)?.[0]
+            .trim() ?? ''
+        )
+
+        const item: DocToC = {
+          level,
+          title,
+          id,
+          url: `${url}#${id}`,
+          description,
+          parent: previous[level - 2] ?? null,
+        }
+        previous[level - 1] = item
+
+        tableOfContents.push(item)
+      }
+
+      return { slug, url, editURL, title, description, nav, content, tableOfContents }
     })
   )
 
-  return docs.sort((a, b) => (a.nav > b.nav ? 1 : -1))
+  return docs.sort((a, b) => a.nav - b.nav)
 }

--- a/utils/rehype.ts
+++ b/utils/rehype.ts
@@ -8,37 +8,16 @@ export interface Node {
   children: Node[]
 }
 
-export interface TocItem {
-  id: string
-  level: number
-  title: string
-  parent?: TocItem
-}
-
 /**
- * Generates a table of contents from page headings.
+ * Makes page headings linkable.
  */
-export function tableOfContents(target = []) {
-  return () => (root: Node) => {
-    const previous = {}
-
+export function headings() {
+  return (root: Node) => {
     for (const node of root.children) {
       if (node.type === 'element' && /^h[1-4]$/.test(node.tagName)) {
-        const level = parseInt(node.tagName[1])
-
         const title = node.children.reduce((acc, { value }) => `${acc}${value}`, '')
         const id = title.toLowerCase().replace(/\s+|-+/g, '-')
         node.properties.id = id
-
-        const item: TocItem = {
-          id,
-          level,
-          title,
-          parent: previous[level - 2] ?? null,
-        }
-        previous[level - 1] = item
-
-        target.push(item)
       }
     }
   }

--- a/utils/rehype.ts
+++ b/utils/rehype.ts
@@ -1,3 +1,5 @@
+import { slugify } from './text'
+
 export interface Node {
   type: string
   name?: string
@@ -16,7 +18,7 @@ export function headings() {
     for (const node of root.children) {
       if (node.type === 'element' && /^h[1-4]$/.test(node.tagName)) {
         const title = node.children.reduce((acc, { value }) => `${acc}${value}`, '')
-        const id = title.toLowerCase().replace(/\s+|-+/g, '-')
+        const id = slugify(title)
         node.properties.id = id
       }
     }

--- a/utils/text.ts
+++ b/utils/text.ts
@@ -38,6 +38,11 @@ export const sanitize = (markdown?: string) =>
     .replace(/~(.*?)~/g, '$1')
 
 /**
+ * Converts a TitleCase string into a url-safe slug.
+ */
+export const slugify = (title: string) => title.toLowerCase().replace(/\s+|-+/g, '-')
+
+/**
  * Escapes special characters from text input.
  */
 export const escape = (text: string) => text.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')

--- a/utils/text.ts
+++ b/utils/text.ts
@@ -1,4 +1,43 @@
 /**
+ * Sanitizes markdown formatting from a string, returning plaintext.
+ */
+export const sanitize = (markdown?: string) =>
+  markdown // Remove HTML tags
+    ?.replace(/<[^>]*>/g, '')
+    // Remove setext-style headers
+    .replace(/^[=\-]{2,}\s*$/g, '')
+    // Remove footnotes?
+    .replace(/\[\^.+?\](\: .*?$)?/g, '')
+    .replace(/\s{0,2}\[.*?\]: .*?$/g, '')
+    // Remove images
+    .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, '$1')
+    // Remove inline links
+    .replace(/\[([^\]]*?)\][\[\(].*?[\]\)]/g, '$1')
+    // Remove blockquotes
+    .replace(/^(\n)?\s{0,3}>\s?/gm, '$1')
+    // .replace(/(^|\n)\s{0,3}>\s?/g, '\n\n')
+    // Remove reference-style links?
+    .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
+    // Remove atx-style headers
+    .replace(/^(\n)?\s{0,}#{1,6}\s*( (.+))? +#+$|^(\n)?\s{0,}#{1,6}\s*( (.+))?$/gm, '$1$3$4$6')
+    // Remove * emphasis
+    .replace(/([\*]+)(\S)(.*?\S)??\1/g, '$2$3')
+    // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if
+    //   1. Either there is a whitespace character before opening _ and after closing _.
+    //   2. Or _ is at the start/end of the string.
+    .replace(/(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g, '$1$3$4$5')
+    // Remove code blocks
+    .replace(/(`{3,})(.*?)\1/gm, '$2')
+    // Remove inline code
+    .replace(/`(.+?)`/g, '$1')
+    // // Replace two or more newlines with exactly two? Not entirely sure this belongs here...
+    // .replace(/\n{2,}/g, '\n\n')
+    // // Remove newlines in a paragraph
+    // .replace(/(\S+)\n\s*(\S+)/g, '$1 $2')
+    // Replace strike through
+    .replace(/~(.*?)~/g, '$1')
+
+/**
  * Escapes special characters from text input.
  */
 export const escape = (text: string) => text.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')


### PR DESCRIPTION
Improves search relevance by including page headings and their descriptions in search results. Search results are also properly ranked by match % instead of the starting index (which would de-rank complete matches).


https://user-images.githubusercontent.com/23324155/185773909-9435f674-b90b-4568-98a7-25dfada75e3e.mp4

