### PR TITLE
refactor: label results' pages in search

### DIFF
--- a/src/components/Search/SearchItem.tsx
+++ b/src/components/Search/SearchItem.tsx
@@ -1,16 +1,11 @@
 import Link from 'next/link'
 import Icon from 'components/Icon'
 import { highlight } from 'utils/text'
-
-export interface SearchResult {
-  title: string
-  description: string
-  url: string
-}
+import type { DocToC } from 'hooks/useDocs'
 
 export interface SearchItemProps {
   search: string
-  result: SearchResult
+  result: DocToC
 }
 
 function SearchItem({ search, result }: SearchItemProps) {
@@ -22,6 +17,7 @@ function SearchItem({ search, result }: SearchItemProps) {
             <span
               dangerouslySetInnerHTML={{
                 __html: `
+                <span class="block text-xs text-gray-400 pb-1">${result.page}</span>
                 ${highlight(result.title, search)}
                 <span class="block text-sm text-gray-600 pt-2">
                   ${highlight(result.description, search)}

--- a/src/components/Search/SearchModal.tsx
+++ b/src/components/Search/SearchModal.tsx
@@ -1,11 +1,12 @@
+import clsx from 'clsx'
 import * as React from 'react'
 import Icon from 'components/Icon'
-import SearchItem, { SearchResult } from './SearchItem'
-import clsx from 'clsx'
+import SearchItem from './SearchItem'
+import type { DocToC } from 'hooks/useDocs'
 
 export interface SearchModelProps {
   search: string
-  results: SearchResult[]
+  results: DocToC[]
   onClose: React.MouseEventHandler<HTMLButtonElement>
   onChange: React.ChangeEventHandler<HTMLInputElement>
 }

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -5,9 +5,8 @@ import { useLockBodyScroll } from 'hooks/useLockBodyScroll'
 import SearchModal from './SearchModal'
 import Icon from 'components/Icon'
 import { matchSorter } from 'match-sorter'
-import { useDocs } from 'hooks/useDocs'
+import { useDocs, DocToC } from 'hooks/useDocs'
 import { escape } from 'utils/text'
-import type { SearchResult } from './SearchItem'
 
 function Search() {
   const router = useRouter()
@@ -15,7 +14,7 @@ function Search() {
   const [showSearchModal, setShowSearchModal] = React.useState(false)
   const [query, setQuery] = React.useState('')
   const [lib] = router.query.slug as string[]
-  const [results, setResults] = React.useState<SearchResult[]>([])
+  const [results, setResults] = React.useState<DocToC[]>([])
   const escPressed = useKeyPress('Escape')
   const slashPressed = useKeyPress('Slash')
   useLockBodyScroll(showSearchModal)
@@ -25,12 +24,12 @@ function Search() {
       if (!query) return setResults([])
 
       // Get length of matched text in result
-      const relevanceOf = (result: SearchResult) =>
+      const relevanceOf = (result: DocToC) =>
         (result.title.toLowerCase().match(query.toLowerCase())?.length ?? 0) / result.title.length
 
       // Search
-      const entries: SearchResult[] = (docs as SearchResult[])
-        .concat(docs.flatMap(({ tableOfContents }) => tableOfContents))
+      const entries = docs
+        .flatMap(({ tableOfContents }) => tableOfContents)
         .filter((entry) => entry.description.length > 0)
 
       const results = matchSorter(entries, query, {

--- a/src/hooks/useDocs.ts
+++ b/src/hooks/useDocs.ts
@@ -7,6 +7,7 @@ export interface DocToC {
   description: string
   url: string
   parent?: DocToC
+  page: string
 }
 
 export interface Doc {

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -108,6 +108,7 @@ export async function getDocs(lib?: keyof typeof libs): Promise<Doc[]> {
       const previous: Record<number, DocToC> = {}
 
       const tableOfContents: DocToC[] = []
+      const page = title
 
       for (const match of headings) {
         const [heading] = match
@@ -130,6 +131,7 @@ export async function getDocs(lib?: keyof typeof libs): Promise<Doc[]> {
           url: `${url}#${id}`,
           description,
           parent: previous[level - 2] ?? null,
+          page,
         }
         previous[level - 1] = item
 


### PR DESCRIPTION
Shows page titles in search. Also excludes page descriptions from search results.

https://user-images.githubusercontent.com/23324155/185799047-f791583e-21a4-4c98-8959-00b6d90403de.mp4

