### PR TITLE
feat: remove .md extension when parsing anchor components

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import Codesandbox from 'components/Codesandbox'
 import { MDXRemoteProps, MDXRemoteSerializeResult, MDXRemote } from 'next-mdx-remote'
+import { MARKDOWN_REGEX } from 'utils/docs';
 
 const components = {
   Codesandbox,
@@ -76,13 +77,7 @@ const components = {
     const isAnchor = href.startsWith('https://')
     target = isAnchor ? '_blank' : target
     rel = isAnchor ? 'noopener noreferrer' : rel
-
-    const [path, hash] = href.split('#')
-    const isMarkdown = path.endsWith('.md')
-
-    if(!isAnchor && isMarkdown) {
-      href = path.slice(0, -3) + (hash ? `#${hash}` : '')
-    }
+    href = isAnchor ? href : href.replace(MARKDOWN_REGEX, '')
 
     return (
       <a href={href} target={target} rel={rel}>

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -77,6 +77,13 @@ const components = {
     target = isAnchor ? '_blank' : target
     rel = isAnchor ? 'noopener noreferrer' : rel
 
+    const [path, hash] = href.split('#')
+    const isMarkdown = path.endsWith('.md')
+
+    if(!isAnchor && isMarkdown) {
+      href = path.slice(0, -3) + (hash ? `#${hash}` : '')
+    }
+
     return (
       <a href={href} target={target} rel={rel}>
         {children}

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -9,7 +9,7 @@ import { sanitize, slugify } from './text'
 /**
  * Checks for .md(x) file extension
  */
-const MARKDOWN_REGEX = /\.mdx?$/
+export const MARKDOWN_REGEX = /\.mdx?/
 
 /**
  * Uncomments frontMatter from vanilla markdown


### PR DESCRIPTION
Referring to this conversation: https://github.com/pmndrs/zustand/pull/1257#discussion_r962101354
The site needs to support links that contain the `.md` extention so the docs work within Github, but also on the documentation site. 

Example: 
TypeScript link on this page is broken due to the inclusion of the .md extension:
https://docs.pmnd.rs/zustand/guides/flux-inspired-practice

It's worth noting that over in r3f land, internal docs links are treated as full paths such as events on this page: https://docs.pmnd.rs/react-three-fiber/getting-started/installation
This PR won't impact those. 


**Alternatives**

Option 1: Ideally I would've preferred to use something like `new URL(relativeHref, location)` to parse the parts of the href but I'm not sure how to thread through the location in next at build time. 

Option 2: Possibly some regex madness to stripe `.md` but it gets hairy with the hash 