### PR TITLE
fix: flatten headings that contain non-string elements

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import Codesandbox from 'components/Codesandbox'
 import { MDXRemoteProps, MDXRemoteSerializeResult, MDXRemote } from 'next-mdx-remote'
-import { MARKDOWN_REGEX } from 'utils/docs'
+import { MARKDOWN_REGEX, prepareTitleId } from 'utils/docs'
 
 const components = {
   Codesandbox,
@@ -31,9 +31,9 @@ const components = {
       <h2 id={id}>{children}</h2>
     </a>
   ),
-  h3: ({ children, id }: { children: React.ReactNode; id: string }) => (
-    <a href={`#${id}`} className="heading text-xl mb-4 mt-6 tracking-light">
-      <h3 id={id}>{children}</h3>
+  h3: ({ children }: { children: React.ReactNode }) => (
+    <a href={`#${prepareTitleId(children)}`} className="heading text-xl mb-4 mt-6 tracking-light">
+      <h3 id={prepareTitleId(children)}>{children}</h3>
     </a>
   ),
   h4: ({ children, id }: { children: React.ReactNode; id: string }) => (

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -5,6 +5,7 @@ import matter from 'gray-matter'
 import libs from 'data/libraries'
 import type { Doc, DocToC } from 'hooks/useDocs'
 import { sanitize, slugify } from './text'
+import React from 'react'
 
 /**
  * Checks for .md(x) file extension
@@ -142,4 +143,15 @@ export async function getDocs(lib?: keyof typeof libs): Promise<Doc[]> {
   )
 
   return docs.sort((a, b) => a.nav - b.nav)
+}
+
+/**
+ * Converts a React Node to a flat string safe for use as element ids
+ */
+export function prepareTitleId(title: React.ReactNode) {
+  const flatTitle =
+    React.Children.map(title, (element) => {
+      return React.isValidElement(element) ? element.props.children : element
+    }) ?? []
+  return slugify(flatTitle.join(''))
 }


### PR DESCRIPTION
This address this issue in Zustand: https://github.com/pmndrs/zustand/issues/1313

At the moment, titles with a code tag, like "`create` without curried workaround" result in `undefined` as the id.
This PR flattens those ids into a single string