### PR TITLE
refactor: basic audit for SEO

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,1 @@
+User-agent: *

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -39,7 +39,11 @@ export default function Layout({ doc, children }: LayoutProps) {
           </a>
         </Link>
         <Search />
-        <button className="block lg:hidden p-2 mr-2 ml-2" onClick={() => setMenuOpen((v) => !v)}>
+        <button
+          className="block lg:hidden p-2 mr-2 ml-2"
+          onClick={() => setMenuOpen((v) => !v)}
+          aria-label="Menu"
+        >
           <Icon icon="menu" />
         </button>
       </div>
@@ -94,9 +98,9 @@ export default function Layout({ doc, children }: LayoutProps) {
                   <div className="flex justify-between w-full max-w-3xl mx-auto mt-12">
                     {!!previousPage && (
                       <div className="">
-                        <h5 className="mb-2 text-xs font-bold leading-4 text-gray-500 uppercase">
+                        <label className="mb-2 text-xs font-bold leading-4 text-gray-500 uppercase">
                           Previous
-                        </h5>
+                        </label>
                         <div className="text-xl">
                           <Link href={previousPage.url}>
                             <a className="text-gray-900">{previousPage.title}</a>
@@ -106,9 +110,9 @@ export default function Layout({ doc, children }: LayoutProps) {
                     )}
                     {!!nextPage && (
                       <div className="ml-auto text-right">
-                        <h5 className="mb-2 text-xs font-bold leading-4 text-gray-500 uppercase">
+                        <label className="mb-2 text-xs font-bold leading-4 text-gray-500 uppercase">
                           Next
-                        </h5>
+                        </label>
                         <div className="text-xl">
                           <Link href={nextPage.url}>
                             <a className="text-gray-900">{nextPage.title}</a>

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -85,6 +85,29 @@ const components = {
       </a>
     )
   },
+  img: ({
+    src,
+    alt,
+    width,
+    height,
+    ...rest
+  }: {
+    src: string
+    alt: string
+    width: number
+    height: number
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      decoding="async"
+      loading="lazy"
+      alt={alt}
+      width={width}
+      height={height}
+      {...rest}
+    />
+  ),
 }
 
 export default function Post(props: MDXRemoteSerializeResult) {

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -25,9 +25,9 @@ function Toc({ toc }: ToCProps) {
 
   return (
     <div className="flex flex-col justify-between overflow-y-auto sticky max-h-(screen-16) pb-6 top-16">
-      <h5 className="text-gray-900 uppercase tracking-wide font-semibold mt-12 mb-2 text-sm lg:text-xs">
+      <label className="text-gray-900 uppercase tracking-wide font-semibold mt-12 mb-2 text-sm lg:text-xs">
         On This Page
-      </h5>
+      </label>
       {toc.map((item, index) => (
         <h4 key={`${item.title}-${index}`}>
           <a

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,48 +1,7 @@
-import Head from 'next/head'
-import { AppProps } from 'next/app'
+import type { AppProps } from 'next/app'
 import './main.css'
 import './pmndrs.css'
 
-function App({ Component, pageProps }: AppProps) {
-  return (
-    <>
-      <Head>
-        <meta name="googlebot" content="follow, index, noarchive" />
-        <meta name="robots" content="follow, index, noarchive" />
-        <meta name="viewport" content="initial-scale=1,width=device-width" />
-
-        <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-
-        <link rel="manifest" href="/site.webmanifest" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="#000000" />
-        <meta name="apple-mobile-web-app-title" content="PMNDRS" />
-        <meta name="application-name" content="PMNDRS" />
-        <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="msapplication-config" content="/browserconfig.xml" />
-        <meta name="msapplication-navbutton-color" content="#000000" />
-        <meta name="msapplication-starturl" content="https://pmnd.rs/" />
-        <meta name="msapplication-tilecolor" content="#000000" />
-        <meta name="msapplication-tileimage" content="/mstile-144x144.png" />
-        <meta name="msapplication-tooltip" content="PMNDRS" />
-
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:creator" content="@pmndrs" />
-        <meta name="twitter:site" content="@pmndrs" />
-        <meta property="og:locale" content="en_us" />
-        <meta property="og:type" content="website" />
-
-        <link rel="preload" href="/fonts/inter-regular.woff2" as="font" crossOrigin="" />
-        <link rel="preload" href="/fonts/inter-medium.woff2" as="font" crossOrigin="" />
-        <link rel="preload" href="/fonts/inter-semibold.woff2" as="font" crossOrigin="" />
-        <link rel="preload" href="/fonts/inter-bold.woff2" as="font" crossOrigin="" />
-        <link rel="preload" href="/fonts/meslo.woff2" as="font" crossOrigin="" />
-      </Head>
-      <Component {...pageProps} />
-    </>
-  )
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
 }
-
-export default App

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,44 @@
+import { Head, Html, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <meta charSet="utf-8" />
+
+        <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+
+        <link rel="manifest" href="/site.webmanifest" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="#000000" />
+        <meta name="apple-mobile-web-app-title" content="PMNDRS" />
+        <meta name="application-name" content="PMNDRS" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="msapplication-config" content="/browserconfig.xml" />
+        <meta name="msapplication-navbutton-color" content="#000000" />
+        <meta name="msapplication-starturl" content="https://pmnd.rs/" />
+        <meta name="msapplication-tilecolor" content="#000000" />
+        <meta name="msapplication-tileimage" content="/mstile-144x144.png" />
+        <meta name="msapplication-tooltip" content="PMNDRS" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:creator" content="@pmndrs" />
+        <meta name="twitter:site" content="@pmndrs" />
+        <meta property="og:locale" content="en_us" />
+        <meta property="og:type" content="website" />
+
+        <link rel="preload" href="/fonts/inter-regular.woff2" as="font" crossOrigin="true" />
+        <link rel="preload" href="/fonts/inter-medium.woff2" as="font" crossOrigin="true" />
+        <link rel="preload" href="/fonts/inter-semibold.woff2" as="font" crossOrigin="true" />
+        <link rel="preload" href="/fonts/inter-bold.woff2" as="font" crossOrigin="true" />
+        <link rel="preload" href="/fonts/meslo.woff2" as="font" crossOrigin="" />
+      </Head>
+      <body tabIndex={-1}>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
Makes correct use of headings and SEO configuration. WIP image implementation that will have to be followed up with a rehype plugin to assert its use whenever HTML is explicitly defined in markdown (related: https://github.com/pmndrs/react-three-fiber/commit/e211dbf09461c153d768cad53d439a5fbdcc0b5e, https://github.com/pmndrs/react-three-fiber/commit/66776edb25da84409c25cd01b8001eb414f4385f, https://github.com/pmndrs/react-three-fiber/commit/0a8f3c26d67c61d58d5397de671c38ce2cfcac3a).