### PR TITLE
fix(useLockBodyScroll): prevent CLS when hiding scrollbar

### DIFF
--- a/src/components/Search/SearchModal.tsx
+++ b/src/components/Search/SearchModal.tsx
@@ -12,8 +12,8 @@ export interface SearchModelProps {
 
 function SearchModal({ search, results, onClose, onChange }: SearchModelProps) {
   return (
-    <div className="absolute top-0 left-0 bottom-0 right-0 h-screen z-99">
-      <button className="opacity-50 bg-gray-900 w-full h-screen" onClick={onClose} />
+    <div className="absolute top-0 left-0 bottom-0 right-0 w-screen h-screen z-99">
+      <button className="opacity-50 bg-gray-900 w-full h-full" onClick={onClose} />
       <div className="absolute top-20 bottom-20 overflow-y-auto left-2/4 w-[500px] max-w-[90%] z-100 -translate-x-1/2 transform">
         <div className="mt-1 relative rounded-md shadow-sm">
           <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">

--- a/src/hooks/useLockBodyScroll.ts
+++ b/src/hooks/useLockBodyScroll.ts
@@ -2,12 +2,41 @@ import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 export function useLockBodyScroll(active = false) {
   useIsomorphicLayoutEffect(() => {
+    const outer = document.createElement('div')
+    outer.style.visibility = 'hidden'
+    outer.style.overflow = 'scroll'
+    document.body.appendChild(outer)
+
+    const inner = document.createElement('div')
+    outer.appendChild(inner)
+
+    const scrollbarWidth = outer.offsetWidth - inner.offsetWidth
+    document.body.style.setProperty('--scrollbar-width', `${scrollbarWidth}px`)
+
+    document.body.removeChild(outer)
+  }, [])
+
+  useIsomorphicLayoutEffect(() => {
     if (!active) return
-    // Get original body overflow
-    const originalStyle = window.getComputedStyle(document.body).overflow
-    // Prevent scrolling on mount
-    document.body.style.overflow = 'hidden'
-    // Re-enable scrolling when component unmounts
-    return () => void (document.body.style.overflow = originalStyle)
+
+    const onResize = () => {
+      // Hide the scrollbar
+      document.body.style.overflow = 'hidden'
+
+      // Offset the page by scrollbar width to prevent CLS
+      const scrollbarVisible = document.body.scrollHeight <= document.body.clientHeight
+      document.body.style.paddingRight = scrollbarVisible ? 'var(--scrollbar-width)' : '0px'
+    }
+
+    const resizeObserver = new ResizeObserver(onResize)
+    resizeObserver.observe(document.body)
+    onResize()
+
+    // Unset style overrides on unmount
+    return () => {
+      resizeObserver.disconnect()
+      document.body.style.overflow = 'unset'
+      document.body.style.paddingRight = 'unset'
+    }
   }, [active])
 }


### PR DESCRIPTION
Prevents layout shifts by applying a computed page offset whenever scrollbar visibility is changed.