### PR TITLE
fix(useCSB): add delay between codesandbox api requests to avoid rate limits

### DIFF
--- a/src/hooks/useCSB.ts
+++ b/src/hooks/useCSB.ts
@@ -10,11 +10,16 @@ export interface CSB {
 
 export const CSBContext = React.createContext<Record<string, CSB>>({})
 
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
 export async function fetchCSB(ids: string[]) {
   const boxes: Record<string, CSB> = {}
 
   for (const id of ids) {
     try {
+      // add a delay between requests to avoid being rate limited
+      await wait(100)
+
       const { title, description, alias, screenshot_url, tags } = await fetch(
         `https://codesandbox.io/api/v1/sandboxes/${id}`
       ).then(async (res) => (await res.json()).data)


### PR DESCRIPTION
### Change
- add delay between codesandbox api requests to avoid rate limits

### Motivation
- the r3f docs website "Examples" page isn't rendering codesandbox titles, and links aren't being constructed correctly
- when attempting to build locally, codesandbox rate limited api requests
- it is possible that the vercel builds are being rate limited, resulting in missing codesandboxes data
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/67411435/201062249-aca71cf0-cd02-4a3e-93fd-1ec4121fcae0.png">
